### PR TITLE
Added TreeNode and PathExpression support

### DIFF
--- a/src/tree/TreeNode.ts
+++ b/src/tree/TreeNode.ts
@@ -1,0 +1,43 @@
+
+/**
+ * Core abstraction supporting path expressions.
+ * Represents a tree node. Property and function names begin with $
+ * to ensure they're out of band if we mix in user data
+ */
+export interface TreeNode {
+
+    readonly $name: string;
+
+    $children?: TreeNode[];
+
+    /**
+     * Value, if this is a terminal node
+     */
+    $value?: string;
+
+    /** Offset from 0 in the file, if available */
+    readonly $offset?: number;
+
+}
+
+export function isTerminal(tn: TreeNode): boolean {
+    return tn.$value && !(tn.$children && tn.$children.length > 0);
+}
+
+/**
+ * Visit the node, returning whether to continue
+ * @param {TreeNode} n node to visit
+ * @return {boolean} whether to visit the node's children, if any
+ */
+export type TreeVisitor = (n: TreeNode) => boolean;
+
+/**
+ * Visit the given TreeNode and its children
+ * @param {TreeNode} tn
+ * @param {TreeVisitor} v
+ */
+export function visit(tn: TreeNode, v: TreeVisitor) {
+    if (v(tn)) {
+        (tn.$children || []).forEach(n => visit(n, v));
+    }
+}

--- a/src/tree/ast/FileParser.ts
+++ b/src/tree/ast/FileParser.ts
@@ -1,0 +1,25 @@
+
+import { File } from "../../project/File";
+import { TreeNode } from "../TreeNode";
+
+/**
+ * Implemented by objects that can parse a file into an AST using a single grammar
+ */
+export interface FileParser {
+
+    /**
+     * Name of the top level production: name of the root TreeNode
+     */
+    rootName: string;
+
+    /**
+     * Parse a file, returning an AST
+     * @param {File} f
+     * @return {TreeNode} root tree node
+     */
+    toAst(f: File): Promise<TreeNode>;
+}
+
+export function isFileParser(a: any): a is FileParser {
+    return !!a && !!a.toAst;
+}

--- a/src/tree/ast/FileParserRegistry.ts
+++ b/src/tree/ast/FileParserRegistry.ts
@@ -1,0 +1,49 @@
+import { Dictionary } from "lodash";
+import { isNamedNodeTest } from "../path/nodeTests";
+import { PathExpression } from "../path/pathExpression";
+import { toPathExpression } from "./astUtils";
+import { FileParser } from "./FileParser";
+
+/**
+ * Registry of FileParsers. Allows resolution of the appropriate parser
+ * for a path expression
+ */
+export interface FileParserRegistry {
+
+    /**
+     * Find a parser for the given path expression.
+     * It's first location step must start with a node name.
+     * @param {string | PathExpression} pex
+     * @return {FileParser}
+     */
+    parserFor(pex: string | PathExpression): FileParser | undefined;
+}
+
+/**
+ * Implementation of FileParserRegistry implementing fluent builder pattern
+ */
+export class DefaultFileParserRegistry implements FileParserRegistry {
+
+    private parserRegistry: Dictionary<FileParser> = {};
+
+    public addParser(pr: FileParser): this {
+        this.parserRegistry[pr.rootName] = pr;
+        return this;
+    }
+
+    public parserFor(pathExpression: string | PathExpression): FileParser | any {
+        const parsed: PathExpression = toPathExpression(pathExpression);
+        const test = parsed.locationSteps[0].test;
+        if (isNamedNodeTest(test)) {
+            const parser = this.parserRegistry[test.name];
+            if (!!parser) {
+                return parser;
+            }
+        }
+        return undefined;
+    }
+
+    public toString() {
+        return `DefaultFileParserRegistry: parsers=[${Object.getOwnPropertyNames(this.parserRegistry)}]`;
+    }
+}

--- a/src/tree/ast/astUtils.ts
+++ b/src/tree/ast/astUtils.ts
@@ -1,0 +1,125 @@
+import { File } from "../../project/File";
+
+import * as _ from "lodash";
+
+import { logger } from "../../internal/util/logger";
+
+import { ProjectNonBlocking, ProjectScripting } from "../../project/Project";
+import { saveFromFilesAsync } from "../../project/util/projectUtils";
+import { defineDynamicProperties } from "../enrichment";
+import { evaluateExpression } from "../path/expressionEngine";
+import { isSuccessResult, PathExpression } from "../path/pathExpression";
+import { parsePathExpression } from "../path/pathExpressionParser";
+import { TreeNode } from "../TreeNode";
+import { FileParser, isFileParser } from "./FileParser";
+import { FileParserRegistry } from "./FileParserRegistry";
+
+/**
+ * Represents a file and the hits against it
+ */
+export class FileHit {
+
+    constructor(private project: ProjectScripting, public file: File, public readonly matches: TreeNode[]) {
+        interface Update {
+            initialValue: string;
+            currentValue: string;
+            offset: number;
+        }
+
+        const updates: Update[] = [];
+
+        function doReplace(): Promise<File> {
+            return file.getContent().then(content => {
+                // Replace in reverse order so that offsets work
+                let newContent = content;
+                for (const u of updates) {
+                    logger.debug("Applying update " + JSON.stringify(u));
+                    newContent = newContent.substr(0, u.offset) +
+                        newContent.substr(u.offset).replace(u.initialValue, u.currentValue);
+                }
+                return file.setContent(newContent);
+            });
+        }
+
+        // Define a "value" property on each match that causes the project to be updated
+        matches.forEach(m => {
+            const initialValue = m.$value;
+            let currentValue = m.$value;
+            Object.defineProperty(m, "$value", {
+                get() {
+                    return currentValue;
+                },
+                set(v2) {
+                    logger.info("Updating value from [%s] to [%s] on [%s]", currentValue, v2, m.$name);
+                    // TODO allow only one
+                    currentValue = v2;
+                    updates.push({initialValue, currentValue, offset: m.$offset});
+                    updates.sort(u => -u.offset);
+                },
+            });
+        });
+        project.recordAction(p => doReplace());
+    }
+}
+
+/**
+ * Integrate path expressions with project operations to find all matches
+ * @param p project
+ * @param globPattern file glob pattern
+ * @param parserOrRegistry parser for files
+ * @param pathExpression path expression string or parsed
+ * @return {Promise<TreeNode[]>} hit record for each matching file
+ */
+export function findMatches(p: ProjectNonBlocking,
+                            globPattern: string,
+                            parserOrRegistry: FileParser | FileParserRegistry,
+                            pathExpression: string | PathExpression): Promise<TreeNode[]> {
+    return findFileMatches(p, globPattern, parserOrRegistry, pathExpression)
+        .then(fileHits => _.flatten(fileHits.map(f => f.matches)));
+}
+
+export function findFileMatches(p: ProjectNonBlocking,
+                                globPattern: string,
+                                parserOrRegistry: FileParser | FileParserRegistry,
+                                pathExpression: string | PathExpression): Promise<FileHit[]> {
+    const parsed: PathExpression = toPathExpression(pathExpression);
+    const parser = findParser(parsed, parserOrRegistry);
+    if (!parser) {
+        throw new Error(`Cannot find parser for path expression [${pathExpression}]: Using ${parserOrRegistry}`);
+    }
+    return saveFromFilesAsync<FileHit>(p, globPattern, file => {
+        return parser.toAst(file)
+            .then(root => {
+                logger.debug("Successfully parsed file [%s] to AST with root node named [%s]. Will execute [%s]",
+                    file.path, root.$name, pathExpression);
+                defineDynamicProperties(root);
+                // logger.debug(JSON.stringify(root, null, 1));
+                // Put in an artificial container: The root
+                const container: TreeNode = { $name: file.name, $children: [ root ] };
+                const r = evaluateExpression(container, parsed);
+                if (isSuccessResult(r)) {
+                    logger.debug("%d matches in file [%s]", r.length, file.path);
+                    return new FileHit(p, file, r);
+                } else {
+                    logger.debug("No matches in file [%s]", file.path);
+                    return undefined;
+                }
+            })
+            .catch(err => {
+                logger.info("Failed to parse file [%s]: %s", file.path, err);
+                return undefined;
+            });
+    });
+}
+
+export function toPathExpression(pathExpression: string | PathExpression): PathExpression {
+    return (typeof pathExpression === "string") ?
+        parsePathExpression(pathExpression) :
+        pathExpression;
+}
+
+export function findParser(pathExpression: PathExpression, fp: FileParser | FileParserRegistry): FileParser {
+    return (isFileParser(fp)) ?
+        fp :
+        fp.parserFor(pathExpression);
+}

--- a/src/tree/ast/microgrammar/MicrogrammarBasedFileParser.ts
+++ b/src/tree/ast/microgrammar/MicrogrammarBasedFileParser.ts
@@ -1,0 +1,56 @@
+import { TreeNode } from "../../TreeNode";
+import { FileParser } from "../FileParser";
+
+import { Microgrammar } from "@atomist/microgrammar/Microgrammar";
+import { isTreePatternMatch, PatternMatch } from "@atomist/microgrammar/PatternMatch";
+import { File } from "../../../project/File";
+import { defineDynamicProperties } from "../../enrichment";
+
+/**
+ * Allow path expressions against results from a single microgrammar
+ */
+export class MicrogrammarBasedFileParser implements FileParser {
+
+    constructor(public rootName: string,
+                public matchName: string,
+                public grammar: Microgrammar<any>) {
+    }
+
+    public toAst(f: File): Promise<TreeNode> {
+        return f.getContent().then(content => {
+            const matches = this.grammar.findMatches(content);
+            const root = {
+                $name: this.rootName,
+                $children: matches.map(m => new MicrogrammarBackedTreeNode(this.matchName, m)),
+            };
+            defineDynamicProperties(root);
+            return root;
+        });
+    }
+}
+
+class MicrogrammarBackedTreeNode implements TreeNode {
+
+    public readonly $children: TreeNode[];
+
+    public $value: string;
+
+    public readonly $offset: number;
+
+    constructor(public $name: string, m: PatternMatch) {
+        this.$offset = m.$offset;
+        if (isTreePatternMatch(m)) {
+            const subs = m.submatches();
+            this.$children = Object.getOwnPropertyNames(subs)
+                .map(prop => {
+                    const sub = subs[prop];
+                    console.log("Exposing child %s.%s as [%s]", $name, prop, JSON.stringify(sub));
+                    return new MicrogrammarBackedTreeNode(prop, sub);
+                });
+        } else {
+            console.log("Exposing terminal %s as [%s]: value=[%s]", $name,  JSON.stringify(m), m.$matched);
+            this.$value = String(m.$value);
+        }
+    }
+
+}

--- a/src/tree/enrichment.ts
+++ b/src/tree/enrichment.ts
@@ -1,0 +1,40 @@
+
+import { logger } from "../internal/util/logger";
+import { isTerminal, TreeNode, TreeVisitor, visit } from "./TreeNode";
+
+/**
+ * Define properties allowing navigation down the tree.
+ * Terminal properties have their value directly exposed.
+ * There are 2 properties for non-terminals: scalar, and array with a following "s"
+ * @param {TreeNode} root
+ */
+export function defineDynamicProperties(root: TreeNode): void {
+    const propertyAdder: TreeVisitor = (n: TreeNode) => {
+        // TODO what about arrays
+        (n.$children || []).forEach(kid => {
+            addChildProperty(n, kid.$name, kid) ;
+        });
+        return true;
+    };
+    visit(root, propertyAdder);
+}
+
+function addChildProperty(n: TreeNode, key: string, value: TreeNode): void {
+    const valueToUse = isTerminal(value) ? value.$value : value;
+    if (!n[pluralName(key)]) {
+        n[pluralName(key)] = [];
+    }
+    n[pluralName(key)].push(valueToUse);
+    logger.debug("Adding property %s to node name %s", key, n.$name);
+    if (!n[key]) {
+        Object.defineProperty(n, key, {
+            get() {
+                return valueToUse;
+            },
+        });
+    }
+}
+
+function pluralName(key: string): string {
+    return key + "s";
+}

--- a/src/tree/path/expressionEngine.ts
+++ b/src/tree/path/expressionEngine.ts
@@ -1,0 +1,39 @@
+/**
+ * Evaluates path expressions, whether as raw strings or parsed.
+ */
+import { TreeNode } from "../TreeNode";
+import { ExecutionResult, isSuccessResult, PathExpression } from "./pathExpression";
+
+import * as _ from "lodash";
+
+export type ExpressionEngine = (node: TreeNode, parsed: PathExpression) => ExecutionResult;
+
+/**
+ * Return the result of evaluating the expression. If the expression is invalid
+ * return a message, otherwise the result of invoking the valid expression.
+ *
+ * @param node         root node to evaluateExpression the path against
+ * @param pex       Parsed path expression. It's already been validated
+ * @return
+ */
+export function evaluateExpression(node: TreeNode,
+                                   pex: PathExpression): ExecutionResult {
+    let currentResult: ExecutionResult = [ node ];
+    for (const locationStep of pex.locationSteps) {
+        if (isSuccessResult(currentResult)) {
+            if (currentResult.length > 0) {
+                const allNextNodes =
+                    currentResult.map(n => locationStep.follow(n, evaluateExpression));
+                const next = _.flatten(allNextNodes);
+                console.log("Executing location step %s against [%s]:count=%d",
+                    locationStep,
+                    currentResult.map(n => n.$name).join(","),
+                    next.length);
+                currentResult = next;
+            }
+        } else {
+            return currentResult;
+        }
+    }
+    return currentResult;
+}

--- a/src/tree/path/nodeTests.ts
+++ b/src/tree/path/nodeTests.ts
@@ -1,0 +1,56 @@
+import { TreeNode } from "../TreeNode";
+import { AxisSpecifier, NodeTest } from "./pathExpression";
+
+import * as _ from "lodash";
+
+export const AllNodeTest: NodeTest = {
+
+    name: "AllNodes",
+
+    follow(tn: TreeNode, axis: AxisSpecifier) {
+        switch (axis) {
+            case "child" :
+                return tn.$children || [];
+            case "descendant" :
+                return allDescendants(tn);
+            default:
+                throw new Error(`Unsupported axis [${axis}]`);
+        }
+    },
+
+    toString() {
+        return "*";
+    },
+} as NodeTest;
+
+export class NamedNodeTest implements NodeTest {
+
+    constructor(public name: string) {}
+
+    public follow(tn: TreeNode, axis: AxisSpecifier) {
+        switch (axis) {
+            case "child" :
+                return (tn.$children || []).filter(n => n.$name === this.name);
+            case "descendant" :
+                return allDescendants(tn).filter(n => n.$name === this.name);
+            default:
+                throw new Error(`Unsupported axis [${axis}]`);
+        }
+    }
+
+    public toString() {
+        return this.name;
+    }
+}
+
+export function isNamedNodeTest(t: NodeTest): t is NamedNodeTest {
+    return !!t && !!(t as NamedNodeTest).name;
+}
+
+export function allDescendants(tn: TreeNode): TreeNode[] {
+    if (!tn.$children) {
+        return [];
+    }
+    return (tn.$children || []).concat(
+        _.flatMap(tn.$children.map(kid => allDescendants(kid))));
+}

--- a/src/tree/path/pathExpression.ts
+++ b/src/tree/path/pathExpression.ts
@@ -1,0 +1,90 @@
+import { TreeNode } from "../TreeNode";
+import { ExpressionEngine } from "./expressionEngine";
+
+/**
+ * One of the three core elements of a LocationStep. Borrowed from XPath.
+ * Determines the kind of navigation.
+ */
+export type AxisSpecifier = "self" | "child" | "descendant";
+
+export type FailureResult = string;
+
+export type SuccessResult = TreeNode[];
+
+/**
+ * Result of executing a path expression
+ */
+export type ExecutionResult = FailureResult | SuccessResult;
+
+export function isSuccessResult(a: any): a is SuccessResult {
+    return !!a && !!a.length;
+}
+
+/**
+ * One of the three core elements of a LocationStep. Inspired by XPath NodeTest.
+ */
+export interface NodeTest {
+
+    follow(tn: TreeNode, axis: AxisSpecifier,
+           ee: ExpressionEngine): SuccessResult;
+}
+
+/**
+ * Based on the XPath concept of a predicate. A predicate acts on a sequence of nodes
+ * returned from navigation to filter them.
+ */
+export interface Predicate {
+
+    /**
+     * Function taking nodes returned by navigation
+     * to filter them. We test one node with knowledge of all returned nodes.
+     *
+     * @param nodeToTest    node we're testing on;
+     * @param returnedNodes all nodes returned. This argument is
+     *                      often ignored, but can be used to discern the index of the target node.
+     * @param ee expression engine to evaluateExpression
+     */
+    evaluate(nodeToTest: TreeNode,
+             returnedNodes: TreeNode[],
+             ee: ExpressionEngine): boolean;
+}
+
+/**
+ * Step within a path expression
+ */
+export class LocationStep {
+
+    constructor(public axis: AxisSpecifier,
+                public test: NodeTest,
+                public predicates: Predicate[]) {
+    }
+
+    public follow(tn: TreeNode, ee: ExpressionEngine): ExecutionResult {
+        return  this.test.follow(tn, this.axis, ee);
+    }
+
+    public toString() {
+        const preds = this.predicates.length > 0 ?
+            `[${this.predicates.map(p => `[${p}]`).join("")}]` :
+            "";
+        return `${this.axis}::${this.test}${preds}`;
+    }
+
+}
+
+/**
+ * Result of parsing a path expression.
+ */
+export interface PathExpression {
+
+    locationSteps: LocationStep[];
+}
+
+/**
+ * Return an informative string representation of the given path expression
+ * @param {PathExpression} pe
+ * @return {string}
+ */
+export function stringify(pe: PathExpression): string {
+    return pe.locationSteps.map(l => "" + l).join("/");
+}

--- a/src/tree/path/pathExpressionParser.ts
+++ b/src/tree/path/pathExpressionParser.ts
@@ -1,0 +1,92 @@
+
+import { Concat } from "@atomist/microgrammar/matchers/Concat";
+import { Microgrammar } from "@atomist/microgrammar/Microgrammar";
+import { firstOf, optional } from "@atomist/microgrammar/Ops";
+import { isPatternMatch } from "@atomist/microgrammar/PatternMatch";
+import { Rep1Sep, zeroOrMore } from "@atomist/microgrammar/Rep";
+import { logger } from "../../internal/util/logger";
+import { AllNodeTest, NamedNodeTest } from "./nodeTests";
+import { LocationStep, PathExpression, Predicate, stringify } from "./pathExpression";
+import { NestedPathExpressionPredicate, ValuePredicate } from "./predicates";
+
+/**
+ * Parse the given string to path expression. Throw an error in the event of failure.
+ * @param {string} expr expression ot path
+ * @return {PathExpression}
+ */
+export function parsePathExpression(expr: string): PathExpression {
+    const pg = PredicateGrammarDefs as any;
+    // TODO the _initialized property is being added to microgrammar LazyMatcher
+    // to avoid the need for adding a property here
+    if (!pg._initialized) {
+        pg._term = firstOf(ValuePredicateGrammar, AbsolutePathExpressionGrammar);
+        pg._initialized = true;
+        PredicateGrammar._init();
+    }
+
+    const m = AbsolutePathExpressionGrammar.exactMatch(expr);
+    if (isPatternMatch(m)) {
+        logger.debug("Successfully parsed path expression [%s]: %s", expr, stringify(m));
+        return m;
+    } else {
+        logger.info("Error parsing path expression [%s]: %s", expr, m);
+        throw new Error("Failure: " + JSON.stringify(m));
+    }
+}
+
+const NodeName = /[.a-zA-Z0-9_\-$#]+/;
+
+// TODO allow double quotes, and string escaping, and possibly integer literals
+const ValuePredicateGrammar = Microgrammar.fromString<Predicate>(
+    "@${name}='${value}'");
+
+const PredicateGrammarDefs = {
+    _lb: "[",
+    _term: null, // Will be set later to avoid circularity
+    term: ctx => {
+        if (!!ctx._term.name && !!ctx._term.value) {
+            return new ValuePredicate(ctx._term.value);
+        } else if (!!ctx._term.locationSteps) {
+            return new NestedPathExpressionPredicate(ctx._term as PathExpression);
+        }
+        throw new Error(`Unsupported predicate: ${JSON.stringify(ctx._term)}`);
+    },
+    _rb: "]",
+    $lazy: true,
+};
+
+const PredicateGrammar = Concat.of(PredicateGrammarDefs);
+
+const NodeTestGrammar = {
+    _it: firstOf("*", NodeName),
+    test: ctx => ctx._it === "*" ? AllNodeTest : new NamedNodeTest(ctx._it),
+};
+
+const LocationStepGrammar = Microgrammar.fromDefinitions<LocationStep>({
+    _axis: optional(firstOf("/", ".")),
+    axis: ctx => {
+        switch (ctx._axis) {
+            case undefined :
+                return "child";
+            case "/" :
+                return "descendant";
+            case "." :
+                return "self";
+            default:
+                throw new Error(`Unsupported axis specifier [${ctx._axis}]`);
+        }
+    },
+    ...NodeTestGrammar,
+    _predicates: zeroOrMore(PredicateGrammar),
+    predicates: ctx => ctx._predicates.map(p => p.term),
+});
+
+const RelativePathExpressionGrammar = {
+    _locationSteps: new Rep1Sep(LocationStepGrammar, "/"),
+    locationSteps: ctx => ctx._locationSteps.map(l => new LocationStep(l.axis, l.test, l.predicates)),
+};
+
+const AbsolutePathExpressionGrammar = Microgrammar.fromDefinitions<PathExpression>({
+    _slash: "/",
+    ...RelativePathExpressionGrammar,
+});

--- a/src/tree/path/predicates.ts
+++ b/src/tree/path/predicates.ts
@@ -1,0 +1,30 @@
+
+import { TreeNode } from "../TreeNode";
+import { ExpressionEngine } from "./expressionEngine";
+import { PathExpression, Predicate, stringify } from "./pathExpression";
+
+export class ValuePredicate implements Predicate {
+
+    constructor(public $value: string) {}
+
+    public evaluate(nodeToTest: TreeNode, returnedNodes: TreeNode[]): boolean {
+        return nodeToTest.$value === this.$value;
+    }
+
+    public toString() {
+        return `@value='${this.$value}'`;
+    }
+}
+
+export class NestedPathExpressionPredicate implements Predicate {
+
+    constructor(public pathExpression: PathExpression) {}
+
+    public evaluate(nodeToTest: TreeNode, returnedNodes: TreeNode[],  ee: ExpressionEngine): boolean {
+        throw new Error("not yet implemented");
+    }
+
+    public toString() {
+        return stringify(this.pathExpression);
+    }
+}

--- a/test/tree/ast/microgrammar/MicrogrammarBasedFileParserTest.ts
+++ b/test/tree/ast/microgrammar/MicrogrammarBasedFileParserTest.ts
@@ -1,0 +1,107 @@
+import "mocha";
+import * as assert from "power-assert";
+
+import { Microgrammar } from "@atomist/microgrammar/Microgrammar";
+import { Integer } from "@atomist/microgrammar/Primitives";
+import { InMemoryFile } from "../../../../src/project/mem/InMemoryFile";
+import { MicrogrammarBasedFileParser } from "../../../../src/tree/ast/microgrammar/MicrogrammarBasedFileParser";
+import { TreeNode, TreeVisitor, visit } from "../../../../src/tree/TreeNode";
+
+interface Person {
+    name: string;
+    age: number;
+}
+
+describe("MicrogrammarBasedFileParser", () => {
+
+    it("should parse a file", done => {
+        const f = new InMemoryFile("Thing", "Tom:16 Mary:25");
+        const mg = Microgrammar.fromString<Person>("${name}:${age}", {
+            age: Integer,
+        });
+        new MicrogrammarBasedFileParser("people", "person", mg)
+            .toAst(f)
+            .then(root => {
+                console.log(JSON.stringify(root, null, 2));
+                assert(root.$name === "people");
+                assert(root.$children.length === 2);
+                const tom = root.$children[0] as TreeNode;
+                // console.log(JSON.stringify(tom));
+                assert(tom.$name === "person");
+                assert(tom.$children.length === 2);
+                done();
+            }).catch(done);
+    });
+
+    it("should parse a file and allow scalar navigation via property", done => {
+        const f = new InMemoryFile("Thing", "Tom:16 Mary:25");
+        const mg = Microgrammar.fromString<Person>("${name}:${age}", {
+            age: Integer,
+        });
+        new MicrogrammarBasedFileParser("people", "person", mg)
+            .toAst(f)
+            .then(root => {
+                // console.log(JSON.stringify(root, null, 2));
+                assert(root.$name === "people");
+                assert(root.$children.length === 2);
+                const tom = root.$children[0] as Person & TreeNode;
+                assert(tom.$name === "person");
+                assert(tom.name === "Tom", "Name=" + tom.name);
+                done();
+            }).catch(done);
+    });
+
+    it("should parse a file and allow array navigation via property", done => {
+        const f = new InMemoryFile("Thing", "Tom:16 Mary:25");
+        const mg = Microgrammar.fromString<Person>("${name}:${age}", {
+            age: Integer,
+        });
+        new MicrogrammarBasedFileParser("people", "person", mg)
+            .toAst(f)
+            .then(root => {
+                console.log(JSON.stringify(root, null, 2));
+                assert(root.$name === "people");
+                // Check the array property
+                const tom = (root as any).persons[0] as Person & TreeNode;
+                assert(tom.$name === "person");
+                assert(tom.name === "Tom", "Name=" + tom.name);
+                const mary = (root as any).persons[1] as Person & TreeNode;
+                assert(mary.$name === "person");
+                assert(mary.name === "Mary", "Name=" + mary.name);
+                done();
+            }).catch(done);
+    });
+
+    it("should parse a file and keep positions", done => {
+        const f = new InMemoryFile("Thing", "Tom:16 Mary:25");
+        const mg = Microgrammar.fromString<Person>("${name}:${age}", {
+            age: Integer,
+        });
+        new MicrogrammarBasedFileParser("people", "person", mg)
+            .toAst(f)
+            .then(root => {
+                assert(root.$name === "people");
+                let minOffset = -1;
+                let terminalCount = 0;
+                const v: TreeVisitor = tn => {
+                    console.log(tn.$name + "=" + tn.$value + ",offset=" + tn.$offset);
+                    if (tn.$name !== "people") {
+                        assert(tn.$offset !== undefined, `No offset on node with name ${tn.$name}`);
+                        assert(tn.$offset >= minOffset, `Must have position for ${JSON.stringify(tn)}`);
+                        if (!!tn.$value) {
+                            ++terminalCount;
+                            // It's a terminal
+                            assert(f.getContentSync().substr(tn.$offset, tn.$value.length) === tn.$value,
+                                `Unable to validate content for ${JSON.stringify(tn)}`);
+                        }
+                        minOffset = tn.$offset;
+                    }
+                    return true;
+                };
+                visit(root, v);
+                assert(terminalCount > 0);
+                done();
+            }).catch(done);
+    });
+
+});

--- a/test/tree/ast/microgrammar/microgrammarsTest.ts
+++ b/test/tree/ast/microgrammar/microgrammarsTest.ts
@@ -1,0 +1,82 @@
+import "mocha";
+import * as assert from "power-assert";
+
+import { Microgrammar } from "@atomist/microgrammar/Microgrammar";
+import { Integer } from "@atomist/microgrammar/Primitives";
+import { AllFiles } from "../../../../src/project/fileGlobs";
+import { InMemoryProject } from "../../../../src/project/mem/InMemoryProject";
+import { findMatches } from "../../../../src/tree/ast/astUtils";
+import { DefaultFileParserRegistry } from "../../../../src/tree/ast/FileParserRegistry";
+import { MicrogrammarBasedFileParser } from "../../../../src/tree/ast/microgrammar/MicrogrammarBasedFileParser";
+
+interface Person {
+    name: string;
+    age: number;
+}
+
+describe("microgrammar integration and path expression", () => {
+
+    it("should get into AST", done => {
+        const mg = Microgrammar.fromString<Person>("${name}:${age}", {
+            age: Integer,
+        });
+        const fpr = new DefaultFileParserRegistry().addParser(
+            new MicrogrammarBasedFileParser("people", "person", mg));
+        // new MicrogrammarBasedFileParser("people", "person", mg)
+        const p = InMemoryProject.of(
+            {path: "Thing", content: "Tom:16 Mary:25"});
+        findMatches(p, AllFiles, fpr, "/people/person/name")
+            .then(matches => {
+                assert(matches.length === 2);
+                assert(matches[0].$value === "Tom");
+                assert(matches[1].$value === "Mary");
+                done();
+            }).catch(done);
+    });
+
+    it("should get into AST and update single terminal", done => {
+        const mg = Microgrammar.fromString<Person>("${name}:${age}", {
+            age: Integer,
+        });
+        const fpr = new DefaultFileParserRegistry().addParser(
+            new MicrogrammarBasedFileParser("people", "person", mg));
+        // new MicrogrammarBasedFileParser("people", "person", mg)
+        const p = InMemoryProject.of(
+            {path: "Thing", content: "Tom:16 Mary:25"});
+        findMatches(p, AllFiles, fpr, "/people/person/name")
+            .then(matches => {
+                assert(matches.length === 2);
+                assert(matches[0].$value === "Tom");
+                matches[1].$value = "Mark";
+                p.flush()
+                    .then(_ => {
+                        assert(p.findFileSync("Thing").getContentSync() === "Tom:16 Mark:25");
+                        done();
+                    });
+            }).catch(done);
+    });
+
+    it("should get into AST and update two terminals", done => {
+        const mg = Microgrammar.fromString<Person>("${name}:${age}", {
+            age: Integer,
+        });
+        const fpr = new DefaultFileParserRegistry().addParser(
+            new MicrogrammarBasedFileParser("people", "person", mg));
+        // new MicrogrammarBasedFileParser("people", "person", mg)
+        const p = InMemoryProject.of(
+            {path: "Thing", content: "Tom:16 Mary:25"});
+        findMatches(p, AllFiles, fpr, "/people/person/name")
+            .then(matches => {
+                assert(matches.length === 2);
+                assert(matches[0].$value === "Tom");
+                matches[0].$value = "Jose";
+                matches[1].$value = "Mark";
+                p.flush()
+                    .then(_ => {
+                        assert(p.findFileSync("Thing").getContentSync() === "Jose:16 Mark:25");
+                        done();
+                    });
+            }).catch(done);
+    });
+
+});

--- a/test/tree/path/expressionEngineTest.ts
+++ b/test/tree/path/expressionEngineTest.ts
@@ -1,0 +1,53 @@
+import "mocha";
+
+import * as assert from "power-assert";
+import { evaluateExpression } from "../../../src/tree/path/expressionEngine";
+import { AllNodeTest } from "../../../src/tree/path/nodeTests";
+import { LocationStep } from "../../../src/tree/path/pathExpression";
+import { TreeNode } from "../../../src/tree/TreeNode";
+
+describe("expressionEngine", () => {
+
+    it("should evaluateExpression no matches", () => {
+        const tn: TreeNode = {$name: "foo"};
+        const pe = {
+            locationSteps: [new LocationStep("child", AllNodeTest, [])],
+        };
+        const result = evaluateExpression(tn, pe);
+        assert.deepEqual(result, []);
+    });
+
+    it("should find children", () => {
+        const thing1 = {$name: "Thing1"};
+        const thing2 = {$name: "Thing2"};
+        const tn: TreeNode = {
+            $name: "foo", $children: [
+                thing1, thing2,
+            ],
+        };
+        const pe = {
+            locationSteps: [new LocationStep("child", AllNodeTest, [])],
+        };
+        const result = evaluateExpression(tn, pe);
+        assert.deepEqual(result, [ thing1, thing2]);
+    });
+
+    it("should find grandchildren", () => {
+        const grandkid1 = {$name: "Grandkid1"};
+        const grandkid2 = {$name: "Grandkid2"};
+        const thing1 = {$name: "Thing1", $children: [ grandkid1 ]};
+        const thing2 = {$name: "Thing2", $children: [ grandkid2 ]};
+        const tn: TreeNode = {
+            $name: "foo", $children: [
+                thing1, thing2,
+            ],
+        };
+        const pe = {
+            locationSteps: [new LocationStep("descendant", AllNodeTest, [])],
+        };
+        const result = evaluateExpression(tn, pe);
+        assert.deepEqual(result, [ thing1, thing2, grandkid1, grandkid2 ]);
+    });
+
+})
+;

--- a/test/tree/path/pathExpressionParserTest.ts
+++ b/test/tree/path/pathExpressionParserTest.ts
@@ -1,0 +1,131 @@
+import "mocha";
+
+import * as assert from "power-assert";
+import { AllNodeTest, NamedNodeTest } from "../../../src/tree/path/nodeTests";
+import { parsePathExpression } from "../../../src/tree/path/pathExpressionParser";
+import { NestedPathExpressionPredicate, ValuePredicate } from "../../../src/tree/path/predicates";
+
+describe("pathExpressionParser", () => {
+
+    it("should parse all children", () => {
+        const expr = "/*";
+        const parsed = parsePathExpression(expr);
+        assert(parsed.locationSteps.length === 1);
+        assert(parsed.locationSteps[0].axis === "child");
+        assert(parsed.locationSteps[0].test === AllNodeTest, JSON.stringify(parsed.locationSteps[0].test));
+    });
+
+    it("should parse all descendants", () => {
+        const expr = "//*";
+
+        const parsed = parsePathExpression(expr);
+        assert(parsed.locationSteps.length === 1);
+        assert(parsed.locationSteps[0].axis === "descendant");
+        assert(parsed.locationSteps[0].test === AllNodeTest);
+    });
+
+    it("should parse all descendants with name", () => {
+        const expr = "//thing";
+
+        const parsed = parsePathExpression(expr);
+        assert(parsed.locationSteps.length === 1);
+        assert(parsed.locationSteps[0].axis === "descendant");
+        const nt = parsed.locationSteps[0].test as NamedNodeTest;
+        assert(nt.name === "thing");
+    });
+
+    it("should parse named children", () => {
+        const expr = "/foo";
+
+        const parsed = parsePathExpression(expr);
+        assert(parsed.locationSteps.length === 1);
+        assert(parsed.locationSteps[0].axis === "child");
+        const nnt = parsed.locationSteps[0].test as NamedNodeTest;
+        assert(nnt.name === "foo");
+    });
+
+    it("should parse named descendants", () => {
+        const expr = "//foo";
+
+        const parsed = parsePathExpression(expr);
+        assert(parsed.locationSteps.length === 1);
+        assert(parsed.locationSteps[0].axis === "descendant");
+        const nnt = parsed.locationSteps[0].test as NamedNodeTest;
+        assert(nnt.name === "foo");
+        assert(parsed.locationSteps[0].predicates.length === 0);
+    });
+
+    it("should parse named child then named descendants", () => {
+        const expr = "/fizz//foo";
+
+        const parsed = parsePathExpression(expr);
+        assert(parsed.locationSteps.length === 2);
+        assert(parsed.locationSteps[0].axis === "child");
+        const nnt1 = parsed.locationSteps[0].test as NamedNodeTest;
+        assert(nnt1.name === "fizz");
+        assert(parsed.locationSteps[1].axis === "descendant");
+        const nnt2 = parsed.locationSteps[1].test as NamedNodeTest;
+        assert(nnt2.name === "foo");
+    });
+
+    it("should parse named children with attribute", () => {
+        const expr = "/foo[@value='bar']";
+
+        const parsed = parsePathExpression(expr);
+        assert(parsed.locationSteps.length === 1);
+        assert(parsed.locationSteps[0].axis === "child");
+        const nnt = parsed.locationSteps[0].test as NamedNodeTest;
+        assert(nnt.name === "foo");
+        assert(parsed.locationSteps[0].predicates.length === 1);
+        const pred = parsed.locationSteps[0].predicates[0] as ValuePredicate;
+        assert(pred.$value === "bar");
+    });
+
+    it("should parse nested path expression predicate", () => {
+        const expr = "/foo[/bar/baz]";
+
+        const parsed = parsePathExpression(expr);
+        assert(parsed.locationSteps.length === 1);
+        assert(parsed.locationSteps[0].axis === "child");
+        const nnt = parsed.locationSteps[0].test as NamedNodeTest;
+        assert(nnt.name === "foo");
+        assert(parsed.locationSteps[0].predicates.length === 1);
+        const pred = parsed.locationSteps[0].predicates[0] as NestedPathExpressionPredicate;
+        assert(!!pred.pathExpression);
+    });
+
+    it("should parse multiple nested path expression predicates", () => {
+        const expr = "/foo[/bar/baz][/dog/cat]";
+
+        const parsed = parsePathExpression(expr);
+        assert(parsed.locationSteps.length === 1);
+        assert(parsed.locationSteps[0].axis === "child");
+        const nnt = parsed.locationSteps[0].test as NamedNodeTest;
+        assert(nnt.name === "foo");
+        assert(parsed.locationSteps[0].predicates.length === 2);
+        const pred1 = parsed.locationSteps[0].predicates[0] as NestedPathExpressionPredicate;
+        assert(!!pred1.pathExpression);
+        const pred2 = parsed.locationSteps[0].predicates[0] as NestedPathExpressionPredicate;
+        assert(!!pred2.pathExpression);
+    });
+
+    it("should parse nested nested path expression", () => {
+        const expr = "/foo[/bar/baz[/dog/cat]]";
+
+        const parsed = parsePathExpression(expr);
+        assert(parsed.locationSteps.length === 1);
+        assert(parsed.locationSteps[0].axis === "child");
+        const nnt = parsed.locationSteps[0].test as NamedNodeTest;
+        assert(nnt.name === "foo");
+        assert(parsed.locationSteps[0].predicates.length === 1);
+        const pred1 = parsed.locationSteps[0].predicates[0] as NestedPathExpressionPredicate;
+        assert(!!pred1.pathExpression);
+        assert(pred1.pathExpression.locationSteps.length === 2);
+        assert(pred1.pathExpression.locationSteps[1].predicates.length === 1);
+        const pred2 = pred1.pathExpression.locationSteps[1].predicates[0] as NestedPathExpressionPredicate;
+        assert(!!pred2.pathExpression);
+    });
+
+    it("should AND predicates");
+
+});


### PR DESCRIPTION
First cut of `TreeNode` and path expression support. Based on support in old `rug` project, but simplified due to reduction in scope (no longer needing to handle generic graphs).

Includes integration with microgrammars.

Antlr integration will go in a downstream library because of dependencies.