### PR TITLE
Exposes promises directly on utility classes, adding defer method

### DIFF
--- a/src/operations/generate/SeedDrivenGenerator.ts
+++ b/src/operations/generate/SeedDrivenGenerator.ts
@@ -120,7 +120,7 @@ export abstract class SeedDrivenGenerator extends LocalOrRemote implements Handl
     public handle(ctx: HandlerContext): Promise<HandlerResult> {
         return this.repoLoader()(new SimpleRepoId(this.sourceOwner, this.sourceRepo, this.sourceBranch))
             .then(project => {
-                const populated: Promise<Project> = this.manipulateAndFlush(project);
+                const populated: Promise<Project> = this.manipulate(project);
                 return this.local ?
                     populated.then(p => {
                         const parentDir = shell.pwd() + "";
@@ -154,24 +154,13 @@ export abstract class SeedDrivenGenerator extends LocalOrRemote implements Handl
     }
 
     /**
+     * Do the work of the generator.
      * Manipulate and flush--or manipulate synchronously. Leave the project in a ready state
      * for storing.
      * @param {Project} project from seed
      * @return {Promise<Project>}
      */
-    public manipulateAndFlush(project: Project): Promise<Project> {
-        this.manipulate(project);
-        return project.flush();
-    }
-
-    /**
-     * Subclasses can extend this to manipulate the repo
-     * contents from the seed location.  The project is already
-     * populated when this method is called.
-     *
-     * @param project raw seed project
-     */
-    public abstract manipulate(project: ProjectAsync): void;
+    public abstract manipulate(project: Project): Promise<Project>;
 
     protected repoLoader(): RepoLoader {
         assert(this.githubToken, "Github token must be set");

--- a/src/operations/generate/SeedDrivenGenerator.ts
+++ b/src/operations/generate/SeedDrivenGenerator.ts
@@ -9,7 +9,7 @@ import { logger } from "../../internal/util/logger";
 import { GitCommandGitProject } from "../../project/git/GitCommandGitProject";
 import { GitProject } from "../../project/git/GitProject";
 import { NodeFsLocalProject } from "../../project/local/NodeFsLocalProject";
-import { Project, ProjectNonBlocking } from "../../project/Project";
+import { Project, ProjectAsync } from "../../project/Project";
 import { defaultRepoLoader } from "../common/defaultRepoLoader";
 import { LocalOrRemote } from "../common/LocalOrRemote";
 import { SimpleRepoId } from "../common/RepoId";
@@ -171,7 +171,7 @@ export abstract class SeedDrivenGenerator extends LocalOrRemote implements Handl
      *
      * @param project raw seed project
      */
-    public abstract manipulate(project: ProjectNonBlocking): void;
+    public abstract manipulate(project: ProjectAsync): void;
 
     protected repoLoader(): RepoLoader {
         assert(this.githubToken, "Github token must be set");

--- a/src/operations/generate/UniversalSeed.ts
+++ b/src/operations/generate/UniversalSeed.ts
@@ -1,5 +1,6 @@
 import { CommandHandler, MappedParameter, Parameter, Tags } from "../../decorators";
 import { MappedParameters } from "../../Handlers";
+import { defer } from "../../internal/common/Flushable";
 import { logger } from "../../internal/util/logger";
 import { GitProject } from "../../project/git/GitProject";
 import { ProjectNonBlocking } from "../../project/Project";
@@ -62,11 +63,11 @@ export class UniversalSeed extends SeedDrivenGenerator {
      * @param description  brief description of newly created project
      */
     protected cleanReadMe(project: ProjectNonBlocking, description: string): void {
-        doWithFiles(project, "README.md", readMe => {
+        defer(project, doWithFiles(project, "README.md", readMe => {
             readMe.recordReplace(/^#[\\s\\S]*?## Development/, `# ${project.name}
 This project contains ${description}.
 ## Development`);
-        }).defer();
+        }));
     }
 
     /**
@@ -81,8 +82,7 @@ This project contains ${description}.
             "CODE_OF_CONDUCT.md",
             "CONTRIBUTING.md",
         ];
-        deleteFiles(project, "/*", f => filesToDelete.includes(f.path))
-            .defer();
+        defer(project, deleteFiles(project, "/*", f => filesToDelete.includes(f.path)));
         const deleteDirs: string[] = [
             ".travis",
         ];

--- a/src/operations/generate/UniversalSeed.ts
+++ b/src/operations/generate/UniversalSeed.ts
@@ -3,7 +3,7 @@ import { MappedParameters } from "../../Handlers";
 import { defer } from "../../internal/common/Flushable";
 import { logger } from "../../internal/util/logger";
 import { GitProject } from "../../project/git/GitProject";
-import { ProjectNonBlocking } from "../../project/Project";
+import { ProjectAsync } from "../../project/Project";
 import { deleteFiles, doWithFiles } from "../../project/util/projectUtils";
 import { SeedDrivenGenerator } from "./SeedDrivenGenerator";
 
@@ -46,7 +46,7 @@ export class UniversalSeed extends SeedDrivenGenerator {
      *
      * @param project raw seed project
      */
-    public manipulate(project: ProjectNonBlocking): void {
+    public manipulate(project: ProjectAsync): void {
         this.removeSeedFiles(project);
         this.cleanReadMe(project, this.description);
     }
@@ -62,7 +62,7 @@ export class UniversalSeed extends SeedDrivenGenerator {
      * @param project      project whose README should be cleaned
      * @param description  brief description of newly created project
      */
-    protected cleanReadMe(project: ProjectNonBlocking, description: string): void {
+    protected cleanReadMe(project: ProjectAsync, description: string): void {
         defer(project, doWithFiles(project, "README.md", readMe => {
             readMe.recordReplace(/^#[\\s\\S]*?## Development/, `# ${project.name}
 This project contains ${description}.
@@ -74,7 +74,7 @@ This project contains ${description}.
      * Remove files in seed that are not useful, valid, or appropriate
      * for a generated project.
      */
-    protected removeSeedFiles(project: ProjectNonBlocking): void {
+    protected removeSeedFiles(project: ProjectAsync): void {
         const filesToDelete: string[] = [
             ".travis.yml",
             "LICENSE",
@@ -86,7 +86,7 @@ This project contains ${description}.
         const deleteDirs: string[] = [
             ".travis",
         ];
-        deleteDirs.forEach(d => project.recordDeleteDirectory(d));
+        deleteDirs.forEach(d => defer(project, project.deleteDirectory(d)));
     }
 
 }

--- a/src/operations/generate/UniversalSeed.ts
+++ b/src/operations/generate/UniversalSeed.ts
@@ -3,7 +3,7 @@ import { MappedParameters } from "../../Handlers";
 import { defer } from "../../internal/common/Flushable";
 import { logger } from "../../internal/util/logger";
 import { GitProject } from "../../project/git/GitProject";
-import { ProjectAsync } from "../../project/Project";
+import { Project, ProjectAsync } from "../../project/Project";
 import { deleteFiles, doWithFiles } from "../../project/util/projectUtils";
 import { SeedDrivenGenerator } from "./SeedDrivenGenerator";
 
@@ -46,9 +46,10 @@ export class UniversalSeed extends SeedDrivenGenerator {
      *
      * @param project raw seed project
      */
-    public manipulate(project: ProjectAsync): void {
+    public manipulate(project: Project): Promise<Project> {
         this.removeSeedFiles(project);
         this.cleanReadMe(project, this.description);
+        return project.flush();
     }
 
     protected push(gp: GitProject): Promise<any> {

--- a/src/operations/generate/java/JavaSeed.ts
+++ b/src/operations/generate/java/JavaSeed.ts
@@ -1,7 +1,7 @@
 import { CommandHandler, Parameter } from "../../../decorators";
 import { defer } from "../../../internal/common/Flushable";
 import { logger } from "../../../internal/util/logger";
-import { Project, ProjectNonBlocking } from "../../../project/Project";
+import { Project, ProjectAsync } from "../../../project/Project";
 import { deleteFiles } from "../../../project/util/projectUtils";
 import { UniversalSeed } from "../UniversalSeed";
 import { JavaProjectStructure } from "./JavaProjectStructure";
@@ -73,7 +73,7 @@ export class JavaSeed extends UniversalSeed {
      *
      * @param project  project to tailor
      */
-    public manipulate(project: ProjectNonBlocking): void {
+    public manipulate(project: ProjectAsync): void {
         super.manipulate(project);
         const smartArtifactId = (this.artifactId === "${projectName}") ? project.name : this.artifactId;
 
@@ -93,7 +93,7 @@ export class JavaSeed extends UniversalSeed {
      *
      * @param project  Project to remove seed files from.
      */
-    protected removeSeedFiles(project: ProjectNonBlocking): void {
+    protected removeSeedFiles(project: ProjectAsync): void {
         super.removeSeedFiles(project);
         const filesToDelete: string[] = [
             "src/main/scripts/travis-build.bash",

--- a/src/operations/generate/java/JavaSeed.ts
+++ b/src/operations/generate/java/JavaSeed.ts
@@ -1,4 +1,5 @@
 import { CommandHandler, Parameter } from "../../../decorators";
+import { defer } from "../../../internal/common/Flushable";
 import { logger } from "../../../internal/util/logger";
 import { Project, ProjectNonBlocking } from "../../../project/Project";
 import { deleteFiles } from "../../../project/util/projectUtils";
@@ -76,11 +77,11 @@ export class JavaSeed extends UniversalSeed {
         super.manipulate(project);
         const smartArtifactId = (this.artifactId === "${projectName}") ? project.name : this.artifactId;
 
-        updatePom(project as Project, smartArtifactId, this.groupId, this.version, this.description).defer();
+        defer(project, updatePom(project as Project, smartArtifactId, this.groupId, this.version, this.description));
         project.recordAction(p =>
             JavaProjectStructure.infer(p).then(structure =>
                 (structure) ?
-                    movePackage(p, structure.applicationPackage, this.rootPackage).run().then(files => p) :
+                    movePackage(p, structure.applicationPackage, this.rootPackage).then(files => p) :
                     p),
         );
     }
@@ -97,7 +98,7 @@ export class JavaSeed extends UniversalSeed {
         const filesToDelete: string[] = [
             "src/main/scripts/travis-build.bash",
         ];
-        deleteFiles(project, "src/main/scripts/**", f => filesToDelete.includes(f.path)).defer();
+        defer(project, deleteFiles(project, "src/main/scripts/**", f => filesToDelete.includes(f.path)));
     }
 
 }

--- a/src/operations/generate/java/SpringBootSeed.ts
+++ b/src/operations/generate/java/SpringBootSeed.ts
@@ -1,7 +1,7 @@
 import { CommandHandler, Parameter, Tags } from "../../../decorators";
 import { defer } from "../../../internal/common/Flushable";
 import { logger } from "../../../internal/util/logger";
-import { Project, ProjectNonBlocking } from "../../../project/Project";
+import { Project, ProjectAsync } from "../../../project/Project";
 import { doWithFiles } from "../../../project/util/projectUtils";
 import { JavaFiles } from "./javaProjectUtils";
 import { JavaSeed } from "./JavaSeed";
@@ -51,8 +51,8 @@ export class SpringBootSeed extends JavaSeed {
      * @param oldClass   name of class to move from
      * @param newClass   name of class to move to
      */
-    protected renameClassStem(project: ProjectNonBlocking,
-                              oldClass: string, newClass: string): Promise<ProjectNonBlocking> {
+    protected renameClassStem(project: ProjectAsync,
+                              oldClass: string, newClass: string): Promise<ProjectAsync> {
         logger.info("Replacing old class stem [%s] with [%s]", oldClass, newClass);
         return doWithFiles(project, JavaFiles, f => {
             if (f.name.includes(oldClass)) {

--- a/src/operations/generate/java/SpringBootSeed.ts
+++ b/src/operations/generate/java/SpringBootSeed.ts
@@ -1,4 +1,5 @@
 import { CommandHandler, Parameter, Tags } from "../../../decorators";
+import { defer } from "../../../internal/common/Flushable";
 import { logger } from "../../../internal/util/logger";
 import { Project, ProjectNonBlocking } from "../../../project/Project";
 import { doWithFiles } from "../../../project/util/projectUtils";
@@ -50,14 +51,15 @@ export class SpringBootSeed extends JavaSeed {
      * @param oldClass   name of class to move from
      * @param newClass   name of class to move to
      */
-    protected renameClassStem(project: ProjectNonBlocking, oldClass: string, newClass: string): void {
+    protected renameClassStem(project: ProjectNonBlocking,
+                              oldClass: string, newClass: string): Promise<ProjectNonBlocking> {
         logger.info("Replacing old class stem [%s] with [%s]", oldClass, newClass);
-        doWithFiles(project, JavaFiles, f => {
+        return doWithFiles(project, JavaFiles, f => {
             if (f.name.includes(oldClass)) {
                 f.recordRename(f.name.replace(oldClass, newClass));
                 f.recordReplaceAll(oldClass, newClass);
             }
-        }).defer();
+        }).then(files => project);
     }
 
 }

--- a/src/operations/generate/java/javaProjectUtils.ts
+++ b/src/operations/generate/java/javaProjectUtils.ts
@@ -1,6 +1,5 @@
 import { logger } from "../../../internal/util/logger";
-import { File } from "../../../project/File";
-import { Project, ProjectAsync } from "../../../project/Project";
+import { ProjectAsync } from "../../../project/Project";
 import { doWithFiles } from "../../../project/util/projectUtils";
 
 export const JavaFiles = "**/*.java";
@@ -20,9 +19,7 @@ export function movePackage<P extends ProjectAsync>(project: P, oldPackage: stri
     return doWithFiles(project, "**/*.java", f => {
         f.recordReplaceAll(oldPackage, newPackage)
             .recordSetPath(f.path.replace(pathToReplace, newPath));
-    })
-        .then(files => project);
-
+    });
 }
 
 /**

--- a/src/operations/generate/java/javaProjectUtils.ts
+++ b/src/operations/generate/java/javaProjectUtils.ts
@@ -1,4 +1,3 @@
-import { RunOrDefer } from "../../../internal/common/Flushable";
 import { logger } from "../../../internal/util/logger";
 import { File } from "../../../project/File";
 import { ProjectNonBlocking } from "../../../project/Project";
@@ -13,7 +12,7 @@ export const JavaFiles = "**/*.java";
  * @param oldPackage   name of package to move from
  * @param newPackage   name of package to move to
  */
-export function movePackage(project: ProjectNonBlocking, oldPackage: string, newPackage: string): RunOrDefer<File[]> {
+export function movePackage(project: ProjectNonBlocking, oldPackage: string, newPackage: string): Promise<File[]> {
     const pathToReplace = packageToPath(oldPackage);
     const newPath = packageToPath(newPackage);
     logger.info("Replacing path [%s] with [%s], package [%s] with [%s]",

--- a/src/operations/generate/java/javaProjectUtils.ts
+++ b/src/operations/generate/java/javaProjectUtils.ts
@@ -1,6 +1,6 @@
 import { logger } from "../../../internal/util/logger";
 import { File } from "../../../project/File";
-import { ProjectAsync } from "../../../project/Project";
+import { Project, ProjectAsync } from "../../../project/Project";
 import { doWithFiles } from "../../../project/util/projectUtils";
 
 export const JavaFiles = "**/*.java";
@@ -12,7 +12,7 @@ export const JavaFiles = "**/*.java";
  * @param oldPackage   name of package to move from
  * @param newPackage   name of package to move to
  */
-export function movePackage(project: ProjectAsync, oldPackage: string, newPackage: string): Promise<File[]> {
+export function movePackage<P extends ProjectAsync>(project: P, oldPackage: string, newPackage: string): Promise<P> {
     const pathToReplace = packageToPath(oldPackage);
     const newPath = packageToPath(newPackage);
     logger.info("Replacing path [%s] with [%s], package [%s] with [%s]",
@@ -20,7 +20,8 @@ export function movePackage(project: ProjectAsync, oldPackage: string, newPackag
     return doWithFiles(project, "**/*.java", f => {
         f.recordReplaceAll(oldPackage, newPackage)
             .recordSetPath(f.path.replace(pathToReplace, newPath));
-    });
+    })
+        .then(files => project);
 
 }
 

--- a/src/operations/generate/java/javaProjectUtils.ts
+++ b/src/operations/generate/java/javaProjectUtils.ts
@@ -1,6 +1,6 @@
 import { logger } from "../../../internal/util/logger";
 import { File } from "../../../project/File";
-import { ProjectNonBlocking } from "../../../project/Project";
+import { ProjectAsync } from "../../../project/Project";
 import { doWithFiles } from "../../../project/util/projectUtils";
 
 export const JavaFiles = "**/*.java";
@@ -12,7 +12,7 @@ export const JavaFiles = "**/*.java";
  * @param oldPackage   name of package to move from
  * @param newPackage   name of package to move to
  */
-export function movePackage(project: ProjectNonBlocking, oldPackage: string, newPackage: string): Promise<File[]> {
+export function movePackage(project: ProjectAsync, oldPackage: string, newPackage: string): Promise<File[]> {
     const pathToReplace = packageToPath(oldPackage);
     const newPath = packageToPath(newPackage);
     logger.info("Replacing path [%s] with [%s], package [%s] with [%s]",

--- a/src/operations/generate/java/updatePom.ts
+++ b/src/operations/generate/java/updatePom.ts
@@ -1,4 +1,3 @@
-import { File } from "../../../project/File";
 import { Project, ProjectAsync } from "../../../project/Project";
 
 import { doWithFiles } from "../../../project/util/projectUtils";
@@ -11,15 +10,16 @@ import { doWithFiles } from "../../../project/util/projectUtils";
  * @param {string} version
  * @param {string} description
  */
-export function updatePom(project: ProjectAsync,
-                          artifactId: string,
-                          groupId: string,
-                          version: string,
-                          description: string): Promise<File[]> {
+export function updatePom<P extends ProjectAsync>(project: P,
+                                                  artifactId: string,
+                                                  groupId: string,
+                                                  version: string,
+                                                  description: string): Promise<P> {
     return doWithFiles(project, "pom.xml", f => {
         f.recordReplace(/(<artifactId>)([a-zA-Z_.0-9\-]+)(<\/artifactId>)/, "$1" + artifactId + "$3")
             .recordReplace(/(<groupId>)([a-zA-Z_.0-9\-]+)(<\/groupId>)/, "$1" + groupId + "$3")
             .recordReplace(/(<version>)([a-zA-Z_.0-9\-]+)(<\/version>)/, "$1" + version + "$3")
             .recordReplace(/(<description>)([a-zA-Z_.0-9\-]+)(<\/description>)/, "$1" + description + "$3");
-    });
+    })
+        .then(files => project);
 }

--- a/src/operations/generate/java/updatePom.ts
+++ b/src/operations/generate/java/updatePom.ts
@@ -1,7 +1,6 @@
 import { File } from "../../../project/File";
 import { Project, ProjectNonBlocking } from "../../../project/Project";
 
-import { RunOrDefer } from "../../../internal/common/Flushable";
 import { doWithFiles } from "../../../project/util/projectUtils";
 
 /**
@@ -16,7 +15,7 @@ export function updatePom(project: ProjectNonBlocking,
                           artifactId: string,
                           groupId: string,
                           version: string,
-                          description: string): RunOrDefer<File[]> {
+                          description: string): Promise<File[]> {
     return doWithFiles(project, "pom.xml", f => {
         f.recordReplace(/(<artifactId>)([a-zA-Z_.0-9\-]+)(<\/artifactId>)/, "$1" + artifactId + "$3")
             .recordReplace(/(<groupId>)([a-zA-Z_.0-9\-]+)(<\/groupId>)/, "$1" + groupId + "$3")

--- a/src/operations/generate/java/updatePom.ts
+++ b/src/operations/generate/java/updatePom.ts
@@ -1,4 +1,4 @@
-import { Project, ProjectAsync } from "../../../project/Project";
+import { ProjectAsync } from "../../../project/Project";
 
 import { doWithFiles } from "../../../project/util/projectUtils";
 
@@ -20,6 +20,5 @@ export function updatePom<P extends ProjectAsync>(project: P,
             .recordReplace(/(<groupId>)([a-zA-Z_.0-9\-]+)(<\/groupId>)/, "$1" + groupId + "$3")
             .recordReplace(/(<version>)([a-zA-Z_.0-9\-]+)(<\/version>)/, "$1" + version + "$3")
             .recordReplace(/(<description>)([a-zA-Z_.0-9\-]+)(<\/description>)/, "$1" + description + "$3");
-    })
-        .then(files => project);
+    });
 }

--- a/src/operations/generate/java/updatePom.ts
+++ b/src/operations/generate/java/updatePom.ts
@@ -1,5 +1,5 @@
 import { File } from "../../../project/File";
-import { Project, ProjectNonBlocking } from "../../../project/Project";
+import { Project, ProjectAsync } from "../../../project/Project";
 
 import { doWithFiles } from "../../../project/util/projectUtils";
 
@@ -11,7 +11,7 @@ import { doWithFiles } from "../../../project/util/projectUtils";
  * @param {string} version
  * @param {string} description
  */
-export function updatePom(project: ProjectNonBlocking,
+export function updatePom(project: ProjectAsync,
                           artifactId: string,
                           groupId: string,
                           version: string,

--- a/src/project/File.ts
+++ b/src/project/File.ts
@@ -21,6 +21,9 @@ export interface FileCore {
 
 }
 
+/**
+ * Convenient way to defer File operations with fluent API
+ */
 export interface FileScripting extends ScriptedFlushable<File> {
 
     /**
@@ -48,6 +51,8 @@ export interface FileScripting extends ScriptedFlushable<File> {
 export interface FileAsync extends FileCore {
 
     setContent(content: string): Promise<this>;
+
+    rename(name: string): Promise<this>;
 
     getContent(): Promise<string>;
 

--- a/src/project/Project.ts
+++ b/src/project/Project.ts
@@ -1,6 +1,6 @@
 import { Stream } from "stream";
 import { ScriptedFlushable } from "../internal/common/Flushable";
-import { File, FileNonBlocking } from "./File";
+import { File } from "./File";
 
 /**
  * Project operations common to all projects
@@ -8,32 +8,6 @@ import { File, FileNonBlocking } from "./File";
 export interface ProjectCore {
 
     readonly name: string;
-
-}
-
-/**
- * Deferrable project operations, which are recorded for later execution in
- * the flush() function.
- */
-export interface ProjectScripting extends ProjectCore, ScriptedFlushable<Project> {
-
-    /**
-     * Add the given file to the project. Flush afterwards
-     *
-     * @param path {string} The path to use
-     * @param content {string} The content to be placed in the new file
-     */
-    recordAddFile(path: string, content: string): this;
-
-    recordDeleteFile(path: string): this;
-
-    recordDeleteDirectory(path: string): this;
-
-    /**
-     * Track changes to the given file, flushing it when this
-     * project flushes
-     */
-    trackFile(f: FileNonBlocking): this;
 
 }
 
@@ -101,7 +75,7 @@ export interface ProjectSync extends ProjectCore {
 /**
  * Asynchronous Project operations, returning promises or node streams.
  */
-export interface ProjectAsync extends ProjectCore {
+export interface ProjectAsync extends ProjectCore, ScriptedFlushable<Project> {
 
     /**
      * Return a node stream of the files in the project meeting
@@ -149,20 +123,13 @@ export interface ProjectAsync extends ProjectCore {
 }
 
 /**
- * All non blocking project operations.
- */
-export interface ProjectNonBlocking extends ProjectScripting, ProjectAsync {
-
-}
-
-/**
  * Interface representing a project, allowing transparent operations
  * whether it is sourced from a GitHub or other repository, from local disk
  * or in memory. Allows both read and write operations. The three
  * interfaces it extends allow different styles of operation: scripting (deferred),
  * asynchronous (with promises) or synchronous.
  */
-export interface Project extends ProjectScripting, ProjectAsync, ProjectSync {
+export interface Project extends ProjectAsync, ProjectSync {
 
 }
 

--- a/src/project/support/AbstractFile.ts
+++ b/src/project/support/AbstractFile.ts
@@ -26,6 +26,10 @@ export abstract class AbstractFile extends AbstractScriptedFlushable<File> imple
         return this.recordAction(f => f.setContent(newContent));
     }
 
+    public rename(name: string): Promise<this> {
+        return this.setPath(this.path.replace(new RegExp(`${this.name}$`), name));
+    }
+
     public recordRename(name: string): this {
         return this.recordSetPath(this.path.replace(new RegExp(`${this.name}$`), name));
     }

--- a/src/project/util/parseUtils.ts
+++ b/src/project/util/parseUtils.ts
@@ -105,11 +105,11 @@ export function findFileMatches<M>(p: ProjectAsync,
  * @param opts options
  * @return {RunOrDefer<any>}
  */
-export function doWithFileMatches<M>(p: ProjectAsync,
-                                     globPattern: string,
-                                     microgrammar: Microgrammar<M>,
-                                     action: (fh: FileWithMatches<M>) => void,
-                                     opts: Opts = DefaultOpts): Promise<File[]> {
+export function doWithFileMatches<M, P extends ProjectAsync = ProjectAsync>(p: P,
+                                                                            globPattern: string,
+                                                                            microgrammar: Microgrammar<M>,
+                                                                            action: (fh: FileWithMatches<M>) => void,
+                                                                            opts: Opts = DefaultOpts): Promise<P> {
     return doWithFiles(p, globPattern, file => {
         return file.getContent()
             .then(content => {
@@ -139,11 +139,11 @@ export function doWithFileMatches<M>(p: ProjectAsync,
  * @param {{makeUpdatable: boolean}} opts
  * @return {RunOrDefer<File[]>}
  */
-export function doWithUniqueMatch<M>(p: ProjectAsync,
-                                     globPattern: string,
-                                     microgrammar: Microgrammar<M>,
-                                     action: (m: M) => void,
-                                     opts: Opts = DefaultOpts): Promise<File[]> {
+export function doWithUniqueMatch<M, P extends ProjectAsync = ProjectAsync>(p: P,
+                                                                            globPattern: string,
+                                                                            microgrammar: Microgrammar<M>,
+                                                                            action: (m: M) => void,
+                                                                            opts: Opts = DefaultOpts): Promise<P> {
     let count = 0;
     const guardedAction = (fh: FileWithMatches<M>) => {
         if (fh.matches.length !== 1) {
@@ -172,11 +172,11 @@ export function doWithUniqueMatch<M>(p: ProjectAsync,
  * @param {(m: M) => void} action
  * @param {{makeUpdatable: boolean}} opts
  */
-export function doWithAtMostOneMatch<M>(p: ProjectAsync,
-                                        globPattern: string,
-                                        microgrammar: Microgrammar<M>,
-                                        action: (m: M) => void,
-                                        opts: Opts = DefaultOpts): Promise<File[]> {
+export function doWithAtMostOneMatch<M, P extends ProjectAsync = ProjectAsync>(p: P,
+                                                                               globPattern: string,
+                                                                               microgrammar: Microgrammar<M>,
+                                                                               action: (m: M) => void,
+                                                                               opts: Opts = DefaultOpts): Promise<P> {
     let count = 0;
     const guardedAction = (fh: FileWithMatches<M>) => {
         if (fh.matches.length !== 1) {

--- a/src/project/util/projectUtils.ts
+++ b/src/project/util/projectUtils.ts
@@ -1,7 +1,7 @@
-import { defer, ScriptAction } from "../../internal/common/Flushable";
+import { defer } from "../../internal/common/Flushable";
 import { isPromise } from "../../internal/util/async";
-import { File, FileNonBlocking } from "../File";
-import { FileStream, Project, ProjectAsync, ProjectNonBlocking, ProjectScripting } from "../Project";
+import { File } from "../File";
+import { FileStream, ProjectAsync } from "../Project";
 
 /**
  * Promise of an array of files. Usually sourced from Project.streamFiles
@@ -92,7 +92,7 @@ export function saveFromFilesAsync<T>(project: ProjectAsync,
  * @param op operation to perform on files. Can return void or a promise.
  * @return {Promise<T>}
  */
-export function doWithFiles(project: ProjectNonBlocking,
+export function doWithFiles(project: ProjectAsync,
                             globPattern: string,
                             op: (f: File) => void | Promise<any>): Promise<File[]> {
     return new Promise((resolve, reject) => {
@@ -122,7 +122,7 @@ export function doWithFiles(project: ProjectNonBlocking,
  * @param test additional, optional test for files to be deleted
  * @return {RunOrDefer<number>}
  */
-export function deleteFiles<T>(project: ProjectNonBlocking,
+export function deleteFiles<T>(project: ProjectAsync,
                                globPattern: string,
                                test: (f: File) => boolean = f => true): Promise<number> {
         return new Promise((resolve, reject) => {
@@ -131,7 +131,7 @@ export function deleteFiles<T>(project: ProjectNonBlocking,
                 .on("data", f => {
                     if (test(f)) {
                         ++deleted;
-                        project.recordDeleteFile(f.path);
+                        defer(project, project.deleteFile(f.path));
                     }
                 })
                 .on("error", reject)

--- a/src/tree/ast/FileHits.ts
+++ b/src/tree/ast/FileHits.ts
@@ -2,7 +2,7 @@ import { logger } from "../../internal/util/logger";
 
 import { TreeNode } from "@atomist/tree-path/TreeNode";
 import { File } from "../../project/File";
-import { ProjectScripting } from "../../project/Project";
+import { ProjectAsync } from "../../project/Project";
 
 /**
  * Extension of TreeNode that allows convenient addition before
@@ -31,7 +31,7 @@ export class FileHit {
      * we don't need to reparse the file.
      * @param {TreeNode[]} nodes
      */
-    constructor(private project: ProjectScripting,
+    constructor(private project: ProjectAsync,
                 public file: File,
                 public fileNode: TreeNode,
                 public readonly nodes: TreeNode[]) {

--- a/src/tree/ast/astUtils.ts
+++ b/src/tree/ast/astUtils.ts
@@ -6,7 +6,7 @@ import { isSuccessResult, PathExpression } from "@atomist/tree-path/path/pathExp
 import { parsePathExpression } from "@atomist/tree-path/path/pathExpressionParser";
 import { TreeNode } from "@atomist/tree-path/TreeNode";
 import { logger } from "../../internal/util/logger";
-import { ProjectNonBlocking } from "../../project/Project";
+import { ProjectAsync } from "../../project/Project";
 import { saveFromFilesAsync } from "../../project/util/projectUtils";
 import { FileHit, MatchResult } from "./FileHits";
 import { FileParser, isFileParser } from "./FileParser";
@@ -28,7 +28,7 @@ export const ExpressionSeparator = "::";
  * @param parserOrRegistry parser for files
  * @return {Promise<TreeNode[]>} hit record for each matching file
  */
-export function findByExpression(p: ProjectNonBlocking,
+export function findByExpression(p: ProjectAsync,
                                  parserOrRegistry: FileParser | FileParserRegistry,
                                  unifiedExpression: string): Promise<MatchResult[]> {
     const split = unifiedExpression.split(ExpressionSeparator);
@@ -50,7 +50,7 @@ export function findByExpression(p: ProjectNonBlocking,
  * @param pathExpression path expression string or parsed
  * @return {Promise<TreeNode[]>} hit record for each matching file
  */
-export function findMatches(p: ProjectNonBlocking,
+export function findMatches(p: ProjectAsync,
                             parserOrRegistry: FileParser | FileParserRegistry,
                             globPattern: string,
                             pathExpression: string | PathExpression): Promise<MatchResult[]> {
@@ -58,7 +58,7 @@ export function findMatches(p: ProjectNonBlocking,
         .then(fileHits => _.flatten(fileHits.map(f => f.matches)));
 }
 
-export function findFileMatches(p: ProjectNonBlocking,
+export function findFileMatches(p: ProjectAsync,
                                 parserOrRegistry: FileParser | FileParserRegistry,
                                 globPattern: string,
                                 pathExpression: string | PathExpression): Promise<FileHit[]> {

--- a/test/operations/generate/UniversalSeedTest.ts
+++ b/test/operations/generate/UniversalSeedTest.ts
@@ -1,6 +1,7 @@
 import "mocha";
 
 import * as assert from "power-assert";
+import { defer } from "../../../src/internal/common/Flushable";
 import { CommandHandlerMetadata } from "../../../src/internal/metadata/metadata";
 import { metadataFromInstance } from "../../../src/internal/metadata/metadataReading";
 import { JavaSeed } from "../../../src/operations/generate/java/JavaSeed";
@@ -77,7 +78,7 @@ describe("UniversalSeed", () => {
         class SpecialSeed extends UniversalSeed {
 
             public manipulate(p: Project): void {
-                p.recordAddFile("Thing", "1");
+                defer(p, p.addFile("Thing", "1"));
             }
         }
         const seed = new SpecialSeed();

--- a/test/operations/generate/UniversalSeedTest.ts
+++ b/test/operations/generate/UniversalSeedTest.ts
@@ -77,12 +77,12 @@ describe("UniversalSeed", () => {
         const project = InMemoryProject.of(...files);
         class SpecialSeed extends UniversalSeed {
 
-            public manipulate(p: Project): void {
-                defer(p, p.addFile("Thing", "1"));
+            public manipulate(p: Project): Promise<Project> {
+                return p.addFile("Thing", "1");
             }
         }
         const seed = new SpecialSeed();
-        seed.manipulateAndFlush(project)
+        seed.manipulate(project)
             .then(_ => {
                 assert(project.fileCount === files.length + 1,
                     `Expected ${files.length + 1}, got ${ project.fileCount}`);

--- a/test/operations/generate/java/javaProjectUtilsTest.ts
+++ b/test/operations/generate/java/javaProjectUtilsTest.ts
@@ -21,7 +21,7 @@ describe("javaProjectUtils", () => {
     it("should refactor on simple match", done => {
         const t = tempProject();
         t.addFileSync("src/main/java/com/foo/Foo.java", "package com.foo;\npublic class Foo {}");
-        movePackage(t, "com.foo", "com.bar").run()
+        movePackage(t, "com.foo", "com.bar")
             .then(_ => {
                 const found = t.findFileSync("src/main/java/com/bar/Foo.java");
                 assert(found.getContentSync() === "package com.bar;\npublic class Foo {}");
@@ -32,8 +32,7 @@ describe("javaProjectUtils", () => {
     it("should refactor on deeper match", done => {
         const t = tempProject();
         t.addFileSync("src/main/java/com/foo/bar/Foo.java", "package com.foo.bar;\npublic class Foo {}");
-        movePackage(t, "com.foo.bar", "com.something.else").defer();
-        t.flush()
+        movePackage(t, "com.foo.bar", "com.something.else")
             .then(_ => {
                 const found = t.findFileSync("src/main/java/com/something/else/Foo.java");
                 assert(found);

--- a/test/operations/generate/java/updatePomTest.ts
+++ b/test/operations/generate/java/updatePomTest.ts
@@ -23,7 +23,6 @@ describe("updatePom", () => {
         const p = InMemoryProject.of({path: "pom.xml", content: SimplePom});
         p.addFileSync("src/main/java/Foo.java", "public class Foo {}");
         updatePom(p, "art", "group", "version", "desc")
-            .run()
             .then(_ => {
                 const found = p.findFileSync("pom.xml");
                 const newPom = found.getContentSync();

--- a/test/project/local/LocalProjectTest.ts
+++ b/test/project/local/LocalProjectTest.ts
@@ -8,6 +8,7 @@ import { LocalProject } from "../../../src/project/local/LocalProject";
 
 import { File } from "../../../src/project/File";
 
+import { defer } from "../../../src/internal/common/Flushable";
 import { AllFiles, ExcludeNodeModules } from "../../../src/project/fileGlobs";
 import { NodeFsLocalProject } from "../../../src/project/local/NodeFsLocalProject";
 import { InMemoryProject } from "../../../src/project/mem/InMemoryProject";
@@ -148,7 +149,7 @@ describe("LocalProject", () => {
 
     it("adds file", done => {
         const p = tempProject();
-        p.recordAddFile("thing", "1");
+        defer(p, p.addFile("thing", "1"));
         assert(p.dirty);
         p.flush()
             .then(_ => {
@@ -160,7 +161,7 @@ describe("LocalProject", () => {
 
     it("adds nested file", done => {
         const p = tempProject();
-        p.recordAddFile("config/thing", "1");
+        defer(p, p.addFile("config/thing", "1"));
         assert(p.dirty);
         p.flush()
             .then(_ => {
@@ -172,7 +173,7 @@ describe("LocalProject", () => {
 
     it("adds deeply nested file", done => {
         const p = tempProject();
-        p.recordAddFile("config/and/more/thing", "1");
+        defer(p, p.addFile("config/and/more/thing", "1"));
         assert(p.dirty);
         p.flush()
             .then(_ => {
@@ -188,7 +189,7 @@ describe("LocalProject", () => {
         const f1 = p.findFileSync("thing");
         assert(f1.getContentSync() === "1");
         assert(!p.dirty);
-        p.recordDeleteFile("thing");
+        defer(p, p.deleteFile("thing"));
         assert(p.dirty);
         p.flush()
             .then(_ => {

--- a/test/project/util/projectUtilsTest.ts
+++ b/test/project/util/projectUtilsTest.ts
@@ -49,8 +49,7 @@ describe("projectUtils", () => {
         doWithFiles(t, AllFiles, f => {
             f.recordSetContent(f.getContentSync() + "2");
         })
-            .then(files => {
-                assert(files.length === 1);
+            .then(p => {
                 const f = t.findFileSync("Thing");
                 assert(f.getContentSync() === "12");
                 done();
@@ -97,8 +96,8 @@ describe("projectUtils", () => {
         doWithFiles(t, AllFiles, f => {
             return f.setContent(f.getContentSync() + "2");
         })
-            .then(files => {
-                assert(files.length === 1);
+            .then(p => {
+                assert(!!p);
                 const f = t.findFileSync("Thing");
                 assert(f.getContentSync() === "12");
                 done();


### PR DESCRIPTION
Remove `RunOrDefer` and replaced it with simpler `defer` function. Utility methods now return straight promises, but it's still easy to defer (for example, to perform multiple replaces in one operation).

So now `defer(p, p.doThing()` is the opposite of `p.flush()`, enabling us to go in and out of promises at any point.