### PR TITLE
Add atomist-config and atomist-setup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -153,6 +153,16 @@
       "integrity": "sha1-0ifxi8uPPxh+FpZfJESFmgRol1g=",
       "dev": true
     },
+    "@types/inquirer": {
+      "version": "0.0.35",
+      "resolved": "https://registry.npmjs.org/@types/inquirer/-/inquirer-0.0.35.tgz",
+      "integrity": "sha512-/6WyyGROIw6qCmS8KmQtyt9Tj1OX7xIrGloAwMMOaNb3W/+QrrlL4Be4TDvLO4dlvw8gFrHfeXiWxS/k82jgEQ==",
+      "dev": true,
+      "requires": {
+        "@types/rx": "4.1.1",
+        "@types/through": "0.0.29"
+      }
+    },
     "@types/isomorphic-fetch": {
       "version": "0.0.34",
       "resolved": "https://registry.npmjs.org/@types/isomorphic-fetch/-/isomorphic-fetch-0.0.34.tgz",
@@ -256,6 +266,132 @@
       "integrity": "sha1-Jbj922MiJZxrkcNTONObD45SQlI=",
       "dev": true
     },
+    "@types/rx": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@types/rx/-/rx-4.1.1.tgz",
+      "integrity": "sha1-WY/JSla67ZdfGUV04PVy/Y5iekg=",
+      "dev": true,
+      "requires": {
+        "@types/rx-core": "4.0.3",
+        "@types/rx-core-binding": "4.0.4",
+        "@types/rx-lite": "4.0.4",
+        "@types/rx-lite-aggregates": "4.0.3",
+        "@types/rx-lite-async": "4.0.2",
+        "@types/rx-lite-backpressure": "4.0.3",
+        "@types/rx-lite-coincidence": "4.0.3",
+        "@types/rx-lite-experimental": "4.0.1",
+        "@types/rx-lite-joinpatterns": "4.0.1",
+        "@types/rx-lite-testing": "4.0.1",
+        "@types/rx-lite-time": "4.0.3",
+        "@types/rx-lite-virtualtime": "4.0.3"
+      }
+    },
+    "@types/rx-core": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/rx-core/-/rx-core-4.0.3.tgz",
+      "integrity": "sha1-CzNUsSOM7b4rdPYybxOdvHpZHWA=",
+      "dev": true
+    },
+    "@types/rx-core-binding": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/rx-core-binding/-/rx-core-binding-4.0.4.tgz",
+      "integrity": "sha512-5pkfxnC4w810LqBPUwP5bg7SFR/USwhMSaAeZQQbEHeBp57pjKXRlXmqpMrLJB4y1oglR/c2502853uN0I+DAQ==",
+      "dev": true,
+      "requires": {
+        "@types/rx-core": "4.0.3"
+      }
+    },
+    "@types/rx-lite": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/rx-lite/-/rx-lite-4.0.4.tgz",
+      "integrity": "sha1-cQ6/idCi1ZbCEEfZGxJCvO9Rwws=",
+      "dev": true,
+      "requires": {
+        "@types/rx-core": "4.0.3",
+        "@types/rx-core-binding": "4.0.4"
+      }
+    },
+    "@types/rx-lite-aggregates": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/rx-lite-aggregates/-/rx-lite-aggregates-4.0.3.tgz",
+      "integrity": "sha512-MAGDAHy8cRatm94FDduhJF+iNS5//jrZ/PIfm+QYw9OCeDgbymFHChM8YVIvN2zArwsRftKgE33QfRWvQk4DPg==",
+      "dev": true,
+      "requires": {
+        "@types/rx-lite": "4.0.4"
+      }
+    },
+    "@types/rx-lite-async": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/rx-lite-async/-/rx-lite-async-4.0.2.tgz",
+      "integrity": "sha512-vTEv5o8l6702ZwfAM5aOeVDfUwBSDOs+ARoGmWAKQ6LOInQ8J4/zjM7ov12fuTpktUKdMQjkeCp07Vd73mPkxw==",
+      "dev": true,
+      "requires": {
+        "@types/rx-lite": "4.0.4"
+      }
+    },
+    "@types/rx-lite-backpressure": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/rx-lite-backpressure/-/rx-lite-backpressure-4.0.3.tgz",
+      "integrity": "sha512-Y6aIeQCtNban5XSAF4B8dffhIKu6aAy/TXFlScHzSxh6ivfQBQw6UjxyEJxIOt3IT49YkS+siuayM2H/Q0cmgA==",
+      "dev": true,
+      "requires": {
+        "@types/rx-lite": "4.0.4"
+      }
+    },
+    "@types/rx-lite-coincidence": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/rx-lite-coincidence/-/rx-lite-coincidence-4.0.3.tgz",
+      "integrity": "sha512-1VNJqzE9gALUyMGypDXZZXzR0Tt7LC9DdAZQ3Ou/Q0MubNU35agVUNXKGHKpNTba+fr8GdIdkC26bRDqtCQBeQ==",
+      "dev": true,
+      "requires": {
+        "@types/rx-lite": "4.0.4"
+      }
+    },
+    "@types/rx-lite-experimental": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/rx-lite-experimental/-/rx-lite-experimental-4.0.1.tgz",
+      "integrity": "sha1-xTL1y98/LBXaFt7Ykw0bKYQCPL0=",
+      "dev": true,
+      "requires": {
+        "@types/rx-lite": "4.0.4"
+      }
+    },
+    "@types/rx-lite-joinpatterns": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/rx-lite-joinpatterns/-/rx-lite-joinpatterns-4.0.1.tgz",
+      "integrity": "sha1-9w/jcFGKhDLykVjMkv+1a05K/D4=",
+      "dev": true,
+      "requires": {
+        "@types/rx-lite": "4.0.4"
+      }
+    },
+    "@types/rx-lite-testing": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/rx-lite-testing/-/rx-lite-testing-4.0.1.tgz",
+      "integrity": "sha1-IbGdEfTf1v/vWp0WSOnIh5v+Iek=",
+      "dev": true,
+      "requires": {
+        "@types/rx-lite-virtualtime": "4.0.3"
+      }
+    },
+    "@types/rx-lite-time": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/rx-lite-time/-/rx-lite-time-4.0.3.tgz",
+      "integrity": "sha512-ukO5sPKDRwCGWRZRqPlaAU0SKVxmWwSjiOrLhoQDoWxZWg6vyB9XLEZViKOzIO6LnTIQBlk4UylYV0rnhJLxQw==",
+      "dev": true,
+      "requires": {
+        "@types/rx-lite": "4.0.4"
+      }
+    },
+    "@types/rx-lite-virtualtime": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/rx-lite-virtualtime/-/rx-lite-virtualtime-4.0.3.tgz",
+      "integrity": "sha512-3uC6sGmjpOKatZSVHI2xB1+dedgml669ZRvqxy+WqmGJDVusOdyxcKfyzjW0P3/GrCiN4nmRkLVMhPwHCc5QLg==",
+      "dev": true,
+      "requires": {
+        "@types/rx-lite": "4.0.4"
+      }
+    },
     "@types/serve-static": {
       "version": "1.7.32",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.7.32.tgz",
@@ -273,6 +409,15 @@
       "dev": true,
       "requires": {
         "@types/glob": "5.0.33",
+        "@types/node": "8.0.34"
+      }
+    },
+    "@types/through": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/through/-/through-0.0.29.tgz",
+      "integrity": "sha512-9a7C5VHh+1BKblaYiq+7Tfc+EOmjMdZaD1MYtkQjSoxgB69tBjW98ry6SKsi4zEIWztLOMRuL87A3bdT/Fc/4w==",
+      "dev": true,
+      "requires": {
         "@types/node": "8.0.34"
       }
     },
@@ -325,6 +470,22 @@
       "resolved": "https://registry.npmjs.org/acorn-es7-plugin/-/acorn-es7-plugin-1.1.7.tgz",
       "integrity": "sha1-8u4fMiipDurRJF+asZIusucdM2s="
     },
+    "agent-base": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz",
+      "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
+      "requires": {
+        "extend": "3.0.1",
+        "semver": "5.0.3"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
+          "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no="
+        }
+      }
+    },
     "align-text": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
@@ -342,6 +503,11 @@
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
       "dev": true
     },
+    "ansi-escapes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
+      "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ=="
+    },
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
@@ -351,7 +517,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
       "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-      "dev": true,
       "requires": {
         "color-convert": "1.9.0"
       }
@@ -581,7 +746,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
       "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
-      "dev": true,
       "requires": {
         "ansi-styles": "3.2.0",
         "escape-string-regexp": "1.0.5",
@@ -597,6 +761,19 @@
         "node-version": "1.1.0",
         "promise-polyfill": "6.0.2"
       }
+    },
+    "cli-cursor": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "requires": {
+        "restore-cursor": "2.0.0"
+      }
+    },
+    "cli-width": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
     },
     "cliui": {
       "version": "3.2.0",
@@ -629,7 +806,6 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
       "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
-      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -637,8 +813,7 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "colors": {
       "version": "1.0.3",
@@ -1031,8 +1206,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escodegen": {
       "version": "1.9.0",
@@ -1285,6 +1459,26 @@
         "is-extendable": "0.1.1"
       }
     },
+    "external-editor": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.0.5.tgz",
+      "integrity": "sha512-Msjo64WT5W+NhOpQXh0nOHm+n0RfU1QUwDnKYvJ8dEJ8zlwLrqXNTv5mSUTJpepf41PDJGyhueTw2vNZW+Fr/w==",
+      "requires": {
+        "iconv-lite": "0.4.19",
+        "jschardet": "1.5.1",
+        "tmp": "0.0.33"
+      },
+      "dependencies": {
+        "tmp": {
+          "version": "0.0.33",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+          "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+          "requires": {
+            "os-tmpdir": "1.0.2"
+          }
+        }
+      }
+    },
     "eyes": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
@@ -1295,6 +1489,14 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
+    },
+    "figures": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+      "requires": {
+        "escape-string-regexp": "1.0.5"
+      }
     },
     "finalhandler": {
       "version": "1.1.0",
@@ -1365,6 +1567,28 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+    },
+    "github": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/github/-/github-11.0.0.tgz",
+      "integrity": "sha1-7bMt9e+zPK0ATr8L3SpLMLtjqFQ=",
+      "requires": {
+        "follow-redirects": "0.0.7",
+        "https-proxy-agent": "1.0.0",
+        "mime": "1.4.1",
+        "netrc": "0.1.4"
+      },
+      "dependencies": {
+        "follow-redirects": {
+          "version": "0.0.7",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-0.0.7.tgz",
+          "integrity": "sha1-NLkLqyqRGqNHVx2pDyK9NuzYqRk=",
+          "requires": {
+            "debug": "2.6.9",
+            "stream-consume": "0.1.0"
+          }
+        }
+      }
     },
     "glob": {
       "version": "7.1.2",
@@ -1475,8 +1699,7 @@
     "has-flag": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-      "dev": true
+      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
     },
     "he": {
       "version": "1.1.1",
@@ -1515,6 +1738,16 @@
         "statuses": "1.3.1"
       }
     },
+    "https-proxy-agent": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
+      "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
+      "requires": {
+        "agent-base": "2.1.1",
+        "debug": "2.6.9",
+        "extend": "3.0.1"
+      }
+    },
     "iconv-lite": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
@@ -1538,6 +1771,42 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "inquirer": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+      "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+      "requires": {
+        "ansi-escapes": "3.0.0",
+        "chalk": "2.1.0",
+        "cli-cursor": "2.1.0",
+        "cli-width": "2.2.0",
+        "external-editor": "2.0.5",
+        "figures": "2.0.0",
+        "lodash": "4.17.4",
+        "mute-stream": "0.0.7",
+        "run-async": "2.3.0",
+        "rx-lite": "4.0.8",
+        "rx-lite-aggregates": "4.0.8",
+        "string-width": "2.1.1",
+        "strip-ansi": "4.0.0",
+        "through": "2.3.8"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
+        }
+      }
     },
     "interpret": {
       "version": "1.0.4",
@@ -1612,6 +1881,11 @@
       "resolved": "https://registry.npmjs.org/is-negated-glob/-/is-negated-glob-1.0.0.tgz",
       "integrity": "sha1-aRC8pdqMleeEtXUbl2z1oQ/uNtI="
     },
+    "is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
+    },
     "is-relative": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.2.1.tgz",
@@ -1677,6 +1951,11 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
       "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+    },
+    "jschardet": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.5.1.tgz",
+      "integrity": "sha512-vE2hT1D0HLZCLLclfBSfkfTTedhVj0fubHpJBHKwwUWX0nSbhPAfk+SG9rTX95BYNmau8rGFfCeaT6T5OW1C2A=="
     },
     "json-stable-stringify": {
       "version": "1.0.1",
@@ -1861,6 +2140,11 @@
         "js-tokens": "3.0.2"
       }
     },
+    "lru_map": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
+      "integrity": "sha1-tcg1G5Rky9dQM1p5ZQoOwOVhGN0="
+    },
     "lru-cache": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
@@ -1869,11 +2153,6 @@
         "pseudomap": "1.0.2",
         "yallist": "2.1.2"
       }
-    },
-    "lru_map": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
-      "integrity": "sha1-tcg1G5Rky9dQM1p5ZQoOwOVhGN0="
     },
     "make-error": {
       "version": "1.3.0",
@@ -2070,10 +2349,20 @@
         }
       }
     },
+    "mute-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
+    },
     "negotiator": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
       "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
+    },
+    "netrc": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/netrc/-/netrc-0.1.4.tgz",
+      "integrity": "sha1-a+lPysqNd63gqWcNxGCRTJRHJEQ="
     },
     "node": {
       "version": "8.3.0",
@@ -2161,6 +2450,14 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
         "wrappy": "1.0.2"
+      }
+    },
+    "onetime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "requires": {
+        "mimic-fn": "1.1.0"
       }
     },
     "openurl": {
@@ -2642,6 +2939,15 @@
         "path-parse": "1.0.5"
       }
     },
+    "restore-cursor": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "requires": {
+        "onetime": "2.0.1",
+        "signal-exit": "3.0.2"
+      }
+    },
     "retry": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
@@ -2655,6 +2961,27 @@
       "optional": true,
       "requires": {
         "align-text": "0.1.4"
+      }
+    },
+    "run-async": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+      "requires": {
+        "is-promise": "2.1.0"
+      }
+    },
+    "rx-lite": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
+      "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ="
+    },
+    "rx-lite-aggregates": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
+      "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+      "requires": {
+        "rx-lite": "4.0.8"
       }
     },
     "safe-buffer": {
@@ -2795,6 +3122,11 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
       "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
     },
+    "stream-consume": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.0.tgz",
+      "integrity": "sha1-pB6tGm1ggc63n2WwYZAbbY89HQ8="
+    },
     "stream-shift": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
@@ -2830,6 +3162,14 @@
         }
       }
     },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -2857,14 +3197,6 @@
             "ansi-regex": "3.0.0"
           }
         }
-      }
-    },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "requires": {
-        "safe-buffer": "5.1.1"
       }
     },
     "stringifier": {
@@ -2911,7 +3243,6 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
       "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
-      "dev": true,
       "requires": {
         "has-flag": "2.0.0"
       }
@@ -2920,6 +3251,11 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.4.tgz",
       "integrity": "sha1-Kb9hXUqnEhvdiYsi1LP5vE4qoD0="
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
       "version": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -35,9 +35,11 @@
     "express-force-ssl": "^0.3.2",
     "express-session": "^1.15.6",
     "fs-extra": "^4.0.2",
+    "github": "^11.0.0",
     "glob-stream": "^6.1.0",
     "graphql": "^0.10.0",
     "graphql-tag": "^2.4.2",
+    "inquirer": "^3.3.0",
     "isomorphic-fetch": "^2.2.1",
     "json-stringify-safe": "^5.0.1",
     "lodash": "^4.17.4",
@@ -75,6 +77,7 @@
     "@types/express-session": "^1.15.3",
     "@types/fs-extra": "^4.0.2",
     "@types/graphql": "^0.11.5",
+    "@types/inquirer": "0.0.35",
     "@types/isomorphic-fetch": "0.0.34",
     "@types/json-stringify-safe": "^5.0.0",
     "@types/lodash": "^4.14.77",
@@ -125,7 +128,8 @@
   "bin": {
     "git-info": "./git.info.js",
     "atomist-cli": "./start.cli.js",
-    "atomist-client": "./start.client.js"
+    "atomist-client": "./start.client.js",
+    "atomist-config": "./atomist-config.js"
   },
   "engines": {
     "node": "8.5.x",

--- a/scripts/atomist-setup.bash
+++ b/scripts/atomist-setup.bash
@@ -1,0 +1,108 @@
+#!/bin/bash
+# download and setup Atomist automation client
+# Copyright © 2017  Atomist
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+set -o pipefail
+
+declare Pkg=atomist-setup
+declare Version=0.1.0
+
+# write message to standard out (stdout)
+# usage: msg MESSAGE
+function msg() {
+    echo "$Pkg: $*"
+}
+
+# write message to standard error (stderr)
+# usage: err MESSAGE
+function err() {
+    msg "$*" 1>&2
+}
+
+# usage: main "$@"
+function main () {
+    local arg team slug
+    for arg in "$@"; do
+        case "$arg" in
+            T*)
+                team=$arg
+                ;;
+            */*)
+                slug=$arg
+                ;;
+            *)
+                err "unrecognized argument: $arg"
+                return 1
+                ;;
+        esac
+    done
+
+    if [[ ! $slug ]]; then
+        slug=atomist-blogs/sof-command
+    fi
+    local origin=https://github.com/$slug.git
+
+    msg "setting up Atomist API client $slug"
+    msg "this script will clone $slug, install its dependencies,"
+    msg "build it, create an Atomist config for you, and then start the client."
+    msg ""
+    local answer
+    while :; do
+        read -p "$Pkg: Continue? [Y/n] " answer
+        if [[ $answer == [Yy] || ! $answer ]]; then
+            break
+        elif [[ $answer == [Nn] ]]; then
+            msg "quitting"
+            return 0
+        else
+            err "invalid response: $answer, try again"
+        fi
+    done
+
+    if ! git clone "$origin" "$slug"; then
+        err "failed to clone repository $slug from $origin"
+        return 1
+    fi
+
+    if ! cd "$slug"; then
+        err "failed to change to $slug"
+        return 1
+    fi
+
+    if ! npm install; then
+        err "failed to run 'npm install'"
+        return 1
+    fi
+
+    if ! npm run compile; then
+        err "failed to compile TypeScript"
+        return 1
+    fi
+
+    if ! $(npm bin)/atomist-config $team; then
+        err "failed to configure Atomist, our sincerest apologies"
+        return 1
+    fi
+
+    if ! npm start; then
+        err "failed to start Atomist client"
+        return 1
+    fi
+    msg "switch to your browser and visit http://localhost:2866/"
+}
+
+main "$@" || exit 1
+exit 0

--- a/src/atomist-config.ts
+++ b/src/atomist-config.ts
@@ -1,0 +1,176 @@
+// #!/usr/bin/env node
+/*
+ * Copyright © 2017  Atomist
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import * as fs from "fs-extra";
+import * as GitHubApi from "github";
+import * as inquirer from "inquirer";
+import * as os from "os";
+import * as process from "process";
+
+import { UserConfig, UserConfigFile, writeUserConfig } from "./configuration";
+import { LoggingConfig } from "./internal/util/logger";
+
+LoggingConfig.format = "cli";
+const github = new GitHubApi();
+
+function createGitHubToken(user: string, password: string, mfa?: string): Promise<string> {
+    github.authenticate({
+        type: "basic",
+        username: user,
+        password,
+    });
+    const host = os.hostname();
+    const params: GitHubApi.AuthorizationCreateParams = {
+        scopes: ["read:org"],
+        note: `Atomist API on ${host}`,
+        note_url: "http://www.atomist.com/",
+    };
+    if (mfa) {
+        (params as any).headers = { "X-GitHub-OTP": mfa };
+    }
+    return github.authorization.create(params).then(res => {
+        if (res.data && res.data.token) {
+            return res.data.token;
+        }
+        throw new Error(`GitHub API returned successful but there is no token`);
+    });
+}
+
+function atomistConfig(argv: string[]) {
+
+    if (fs.existsSync(UserConfigFile)) {
+        console.warn(`user configuration file, ${UserConfigFile}, already exists, exiting`);
+        process.exit(0);
+    }
+
+    let gitHubToken: string;
+    let slackTeamId: string;
+    const questions: inquirer.Questions = [];
+    if (process.argv.length < 3) {
+        questions.push({
+            type: "input",
+            name: "teamId",
+            message: "Slack Team ID",
+            validate: value => {
+                if (value.indexOf("T") !== 0) {
+                    return `The Slack team ID you entered should start with 'T' but does not: ${value}`;
+                }
+                return true;
+            },
+        });
+    } else {
+        slackTeamId = process.argv[2];
+    }
+    questions.push(
+        {
+            type: "input",
+            name: "user",
+            message: "GitHub Username",
+            validate: value => {
+                if (!/^[-.A-Za-z0-9]+$/.test(value)) {
+                    return `The GitHub username you entered contains invalid characters: ${value}`;
+                }
+                return true;
+            },
+        },
+        {
+            type: "password",
+            name: "password",
+            message: "GitHub Password",
+            validate: value => {
+                if (value.length < 1) {
+                    return `The GitHub password you entered is empty`;
+                }
+                return true;
+            },
+        },
+        {
+            type: "input",
+            name: "mfa",
+            message: "GitHub 2FA Code",
+            when: answers => {
+                return createGitHubToken(answers.user, answers.password)
+                    .then(token => {
+                        gitHubToken = token;
+                        return false;
+                    })
+                    .catch(err => {
+                        if (err.code === 401 && err.message) {
+                            const msg = JSON.parse(err.message);
+                            const mfaErr = "Must specify two-factor authentication OTP code.";
+                            if ((msg.message as string).indexOf(mfaErr) > -1) {
+                                return true;
+                            }
+                        }
+                        throw err;
+                    });
+            },
+            validate: (value, answers) => {
+                if (!/^\d{6}$/.test(value)) {
+                    return `The GitHub 2FA you entered is invalid, it should be six digits: ${value}`;
+                }
+                return true;
+            },
+        } as any as inquirer.Question,
+    );
+
+    console.log(`
+As part of the initial Atomist configuration, we need to create a
+GitHub personal access token for you that will be used to authenticate
+with the Atomist API.  The personal access token will have "read:org"
+scope, be labeled as being for the "Atomist API", and will be written
+to a file on your local machine.  Atomist does not record the token
+nor your GitHub username and password.
+`);
+    inquirer.prompt(questions).then(answers => {
+        if (!slackTeamId) {
+            slackTeamId = answers.teamId;
+        }
+
+        if (!gitHubToken) {
+            if (answers.mfa) {
+                return createGitHubToken(answers.user, answers.password, answers.mfa)
+                    .then(token => {
+                        return writeUserConfig({
+                            token,
+                            teamIds: [slackTeamId],
+                        });
+                    })
+                    .catch(reason => {
+                        console.error(`failed to create user config: ${JSON.stringify(reason)}`);
+                        process.exit(1);
+                    });
+            } else {
+                console.error(`failed to generate GitHub token with provided credentials`);
+                process.exit(1);
+            }
+        }
+        return writeUserConfig({
+            token: gitHubToken,
+            teamIds: [slackTeamId],
+        });
+    }).then(() => {
+        console.info(`successfully created Atomist user config`);
+        process.exit(0);
+    }).catch(err => {
+        console.error(`failed to create user config: ${JSON.stringify(err)}`);
+        process.exit(1);
+    });
+}
+
+atomistConfig(process.argv);

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1,4 +1,22 @@
+/*
+ * Copyright © 2017  Atomist
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 import * as appRoot from "app-root-path";
+import * as fs from "fs-extra";
 import { HandleCommand } from "./HandleCommand";
 import { HandleEvent } from "./HandleEvent";
 import { logger } from "./internal/util/logger";
@@ -18,27 +36,117 @@ export interface Configuration extends RunOptions {
     };
 }
 
+const UserConfigDir = `${process.env.HOME}/.atomist`;
+export const UserConfigFile = `${UserConfigDir}/client.config.json`;
+const UserConfigEncoding = "utf8";
+
+export interface UserConfig {
+    token?: string;
+    teamIds?: string[];
+    modules?: UserModuleConfig[];
+}
+
+export interface UserModuleConfig {
+    name: string;
+    token?: string;
+    teamIds?: string[];
+}
+
+export interface ModuleConfig {
+    token: string;
+    teamIds: string[];
+}
+
+/*
+ * Write user config securely, creating directories as necessary.
+ */
+export function writeUserConfig(cfg: UserConfig): Promise<void> {
+    return fs.ensureDir(UserConfigDir)
+        .then(() => fs.chmod(UserConfigDir, 0o700))
+        .then(() => fs.writeJson(UserConfigFile, cfg, {
+            spaces: 2,
+            encoding: UserConfigEncoding,
+            mode: 0o600,
+        }));
+}
+
+/*
+ * Try to read user config at $HOME/.atomist/client.config.json and
+ * return the configured tokens and team IDs.  If there are values
+ * specific for the client NPM module as read from the module's
+ * package.json, it will return those, otherwise it falls through to
+ * the default values under the `$default$` key.
+ */
+function getModuleConfig(): ModuleConfig {
+    let userConfig: UserConfig;
+    try {
+        userConfig = fs.readJsonSync(UserConfigFile) as UserConfig;
+    } catch (e) {
+        const err = (e as Error).message;
+        logger.info(`failed to read user config: ${err}`);
+    }
+    let pkgJson: any;
+    try {
+        pkgJson = fs.readJsonSync(`${appRoot.path}/package.json`);
+    } catch (e) {
+        const err = (e as Error).message;
+        logger.info(`failed to read client module name: ${err}`);
+    }
+
+    return resolveModuleConfig(userConfig, pkgJson);
+}
+
+export function resolveModuleConfig(userConfig: UserConfig, pkgJson: any): ModuleConfig {
+    let token: string;
+    let teamIds: string[];
+    if (userConfig) {
+        let clientName: string;
+        if (pkgJson && pkgJson.name) {
+            clientName = pkgJson.name;
+        }
+        if (clientName && userConfig.modules) {
+            const moduleConfig = userConfig.modules.find(m => m.name === clientName);
+            if (moduleConfig) {
+                token = moduleConfig.token;
+                teamIds = moduleConfig.teamIds;
+            }
+        }
+        if (!token && userConfig.token) {
+            token = userConfig.token;
+        }
+        if ((!teamIds || teamIds.length < 1) && userConfig.teamIds) {
+            teamIds = userConfig.teamIds;
+        }
+    }
+
+    return { token, teamIds };
+}
+
 const AtomistConfigFile = "atomist.config.js";
 
 export function findConfiguration(): Configuration {
-    // TODO we could add an env variable ATOMIST_CONFIG for people to specify a path to a file to use
+    const moduleConfig = getModuleConfig();
 
+    // TODO we could add an env variable ATOMIST_CONFIG for people to specify a path to a file to use
     const glob = require("glob");
-    const files = glob.sync(`**/${AtomistConfigFile}`, { ignore: "node_modules/**"});
+    const files = glob.sync(`**/${AtomistConfigFile}`, { ignore: "node_modules/**" });
 
     if (files.length === 0) {
         throw new Error(`No '${AtomistConfigFile}' file found in project`);
     } else if (files.length > 1) {
         throw new Error(`More than one '${AtomistConfigFile}' file found in project: ${files.join(", ")}`);
-    } else {
-        const file = files[0];
-        // This part is tricky but essentially brings in the user's handlers.
-        const config = require(`${appRoot.path}/${file}`).configuration as Configuration;
-        logger.debug("Using configuration from '%s': %s", file, JSON.stringify(config, cleanUp));
-
-        validateConfiguration(config, file);
-        return config;
     }
+
+    const file = files[0];
+    // This part is tricky but essentially brings in the user's handlers.
+    const config = require(`${appRoot.path}/${file}`).configuration as Configuration;
+    logger.debug("Using configuration from '%s': %s", file, JSON.stringify(config, cleanUp));
+    config.token = (config.token) ? config.token : moduleConfig.token;
+    config.teamIds = (config.teamIds && config.teamIds.length > 0) ?
+        config.teamIds : moduleConfig.teamIds;
+
+    validateConfiguration(config, file);
+    return config;
 }
 
 function validateConfiguration(configuration: Configuration, path: string) {

--- a/src/internal/util/logger.ts
+++ b/src/internal/util/logger.ts
@@ -4,10 +4,17 @@ import * as serializeError from "serialize-error";
 import * as winston from "winston";
 import * as context from "./cls";
 
-export function formatter(options: any): string {
-    const executionContext = context.get();
+export let LoggingConfig = {
+    format: "logger",
+};
 
-    let ctx;
+export function formatter(options: any): string {
+    if (LoggingConfig.format === "cli") {
+        return options.message;
+    }
+
+    const executionContext = context.get();
+    let ctx: string;
     if (executionContext) {
         if (executionContext.invocationId) {
             ctx = options.colorize ? winston.config.colorize(options.level, executionContext.invocationId)
@@ -55,7 +62,7 @@ const winstonLogger = new winston.Logger({
             timestamp: true,
             showLevel: true,
             align: true,
-            stderrLevels: [ "error" ],
+            stderrLevels: ["error"],
             formatter,
             // handleExceptions: true,
             // humanReadableUnhandledException: true,

--- a/test/atomist.config.ts
+++ b/test/atomist.config.ts
@@ -45,7 +45,7 @@ class StartUpListener extends AutomationEventListenerSupport {
 export const configuration: Configuration = {
     name: "@atomist/automation-node-tests",
     version: "0.0.6",
-    teamIds: [ "T1L0VDKJP" ],
+    teamIds: ["T1L0VDKJP"],
     commands: [
         () => new HelloWorld(),
         () => new SendStartupMessage(),

--- a/test/configurationTest.ts
+++ b/test/configurationTest.ts
@@ -1,0 +1,111 @@
+/*
+ * Copyright © 2017  Atomist
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import "mocha";
+import * as assert from "power-assert";
+
+import { resolveModuleConfig, UserConfig } from "../src/configuration";
+import { LoggingConfig } from "../src/internal/util/logger";
+
+LoggingConfig.format = "cli";
+
+describe("configuration", () => {
+
+    describe("resolveModuleConfig", () => {
+
+        it("should use the default", () => {
+            const userConfig: UserConfig = {
+                token: "the0con",
+                teamIds: ["TVAPOR", "TSIRE", "TWARNERBROS"],
+                modules: [
+                    { name: "@gainst/me", token: "Borne of the FM Waves of the Heart" },
+                ],
+            };
+            const pkgJson = { name: "@tegan/sara" };
+            const moduleConfig = resolveModuleConfig(userConfig, pkgJson);
+            assert(moduleConfig.token === userConfig.token);
+            assert.deepEqual(moduleConfig.teamIds, userConfig.teamIds);
+        });
+
+        it("should use the module configuration", () => {
+            const userConfig: UserConfig = {
+                token: "the0con",
+                teamIds: ["TVAPOR", "TSIRE", "TWARNERBROS"],
+                modules: [
+                    { name: "@gainst/me", token: "Borne of the FM Waves of the Heart" },
+                    { name: "@tegan/sara", token: "sainthood", teamIds: ["TVAPOR"] },
+                ],
+            };
+            const pkgJson = { name: "@tegan/sara" };
+            const moduleConfig = resolveModuleConfig(userConfig, pkgJson);
+            assert(moduleConfig.token === userConfig.modules[1].token);
+            assert.deepEqual(moduleConfig.teamIds, userConfig.modules[1].teamIds);
+        });
+
+        it("should get the token from the module configuration", () => {
+            const userConfig: UserConfig = {
+                token: "the0con",
+                teamIds: ["TVAPOR", "TSIRE", "TWARNERBROS"],
+                modules: [
+                    { name: "@gainst/me", token: "Borne of the FM Waves of the Heart" },
+                    { name: "@tegan/sara", token: "sainthood" },
+                ],
+            };
+            const pkgJson = { name: "@tegan/sara" };
+            const moduleConfig = resolveModuleConfig(userConfig, pkgJson);
+            assert(moduleConfig.token === userConfig.modules[1].token);
+            assert.deepEqual(moduleConfig.teamIds, userConfig.teamIds);
+        });
+
+        it("should get the teamIds from the module configuration", () => {
+            const userConfig: UserConfig = {
+                token: "the0con",
+                teamIds: ["TVAPOR", "TSIRE", "TWARNERBROS"],
+                modules: [
+                    { name: "@gainst/me", token: "Borne of the FM Waves of the Heart" },
+                    { name: "@tegan/sara", teamIds: ["TVAPOR"] },
+                ],
+            };
+            const pkgJson = { name: "@tegan/sara" };
+            const moduleConfig = resolveModuleConfig(userConfig, pkgJson);
+            assert(moduleConfig.token === userConfig.token);
+            assert.deepEqual(moduleConfig.teamIds, userConfig.modules[1].teamIds);
+        });
+
+        it("should return nothing", () => {
+            const userConfig: UserConfig = {};
+            const pkgJson = { name: "@tegan/sara" };
+            const moduleConfig = resolveModuleConfig(userConfig, pkgJson);
+            assert(moduleConfig.token === undefined);
+            assert(moduleConfig.teamIds === undefined);
+        });
+
+        it("should handled undefined", () => {
+            const moduleConfig = resolveModuleConfig(undefined, undefined);
+            assert(moduleConfig.token === undefined);
+            assert(moduleConfig.teamIds === undefined);
+        });
+
+        it("should handled null", () => {
+            const moduleConfig = resolveModuleConfig(null, null);
+            assert(moduleConfig.token === undefined);
+            assert(moduleConfig.teamIds === undefined);
+        });
+
+    });
+
+});


### PR DESCRIPTION

Add command to create atomist config.  It will prompt for GitHub
credentials and create a GitHub personal access token and write it to
the config.

Add shell script to clone an Atomist API client repo, call
atomist-config, and start up the client, all in one step.  It can be
called from curl.

Add ability to retain simple console log format on CLIs and in tests.