### PR TITLE
Overhaul of editing and reviewing

### DIFF
--- a/src/internal/util/ActionResult.ts
+++ b/src/internal/util/ActionResult.ts
@@ -8,10 +8,23 @@ export interface ActionResult<T = undefined> {
     /**
      * Target on which we ran the action, if there is one.
      */
-    target: T;
+    readonly target: T;
 
     /**
      * Whether or not the action succeeded.
      */
-    success: boolean;
+    readonly success: boolean;
+}
+
+/**
+ * Convenient implementation of ActionResult
+ */
+export class SimpleActionResult<T> implements ActionResult<T> {
+
+    constructor(public readonly target: T, public readonly success: boolean) {
+    }
+}
+
+export function successOn<T>(t: T): ActionResult<T> {
+    return new SimpleActionResult(t, true);
 }

--- a/src/operations/common/RepoId.ts
+++ b/src/operations/common/RepoId.ts
@@ -27,6 +27,11 @@ export interface RepoId {
     provider: VcsProvider;
 }
 
+export function isRepoId(r: any): r is RepoId {
+    const maybeRi = r as RepoId;
+    return !!maybeRi.owner && !!maybeRi.repo;
+}
+
 export class SimpleRepoId implements RepoId {
 
     constructor(public owner: string,

--- a/src/operations/common/defaultRepoLoader.ts
+++ b/src/operations/common/defaultRepoLoader.ts
@@ -1,3 +1,4 @@
+import { GitProject } from "../../project/git/GitProject";
 import { gitHubRepoLoader } from "./gitHubRepoLoader";
 import { LocalRepoLoader } from "./localRepoLoader";
 import { isLocalDirectory, RepoId } from "./RepoId";
@@ -9,10 +10,10 @@ import { RepoLoader } from "./repoLoader";
  * @return function to materialize repos
  * @constructor
  */
-export function defaultRepoLoader(token: string): RepoLoader {
+export function defaultRepoLoader(token: string): RepoLoader<GitProject> {
     return (repoId: RepoId) => {
         if (isLocalDirectory(repoId.provider)) {
-            return LocalRepoLoader(repoId);
+            return LocalRepoLoader(repoId) as Promise<GitProject>;
         } else {
            return gitHubRepoLoader(token)(repoId);
         }

--- a/src/operations/common/fromProjectList.ts
+++ b/src/operations/common/fromProjectList.ts
@@ -1,0 +1,12 @@
+import { Project } from "../../project/Project";
+import { RepoFinder } from "./repoFinder";
+import { RepoId } from "./RepoId";
+import { RepoLoader } from "./repoLoader";
+
+export function fromListRepoFinder(projects: Project[]): RepoFinder {
+    return () => Promise.resolve(projects.map(p => p.id));
+}
+
+export function fromListRepoLoader(projects: Project[]): RepoLoader {
+    return (id: RepoId) => Promise.resolve(projects.find(p => p.id === id));
+}

--- a/src/operations/common/gitHubPersisters.ts
+++ b/src/operations/common/gitHubPersisters.ts
@@ -1,0 +1,9 @@
+import { HandlerContext } from "../../HandlerContext";
+import { GitProject } from "../../project/git/GitProject";
+import { editProjectUsingPullRequest, PullRequestInfo } from "../support/editorUtils";
+import { ProjectPersister } from "./projectPersister";
+
+export function pullRequestProjectPersister(context: HandlerContext,
+                                            pr: PullRequestInfo): ProjectPersister<GitProject> {
+    return (p, editor) => editProjectUsingPullRequest(context, p, editor, pr);
+}

--- a/src/operations/common/gitHubPersisters.ts
+++ b/src/operations/common/gitHubPersisters.ts
@@ -1,9 +1,0 @@
-import { HandlerContext } from "../../HandlerContext";
-import { GitProject } from "../../project/git/GitProject";
-import { editProjectUsingPullRequest, PullRequestInfo } from "../support/editorUtils";
-import { ProjectPersister } from "./projectPersister";
-
-export function pullRequestProjectPersister(context: HandlerContext,
-                                            pr: PullRequestInfo): ProjectPersister<GitProject> {
-    return (p, editor) => editProjectUsingPullRequest(context, p, editor, pr);
-}

--- a/src/operations/common/gitHubRepoLoader.ts
+++ b/src/operations/common/gitHubRepoLoader.ts
@@ -1,4 +1,5 @@
 import { GitCommandGitProject } from "../../project/git/GitCommandGitProject";
+import { GitProject } from "../../project/git/GitProject";
 import { RepoId } from "./RepoId";
 import { RepoLoader } from "./repoLoader";
 
@@ -8,7 +9,7 @@ import { RepoLoader } from "./repoLoader";
  * @return function to materialize repos
  * @constructor
  */
-export function gitHubRepoLoader(token: string): RepoLoader {
+export function gitHubRepoLoader(token: string): RepoLoader<GitProject> {
     return (repoId: RepoId) => {
         return GitCommandGitProject.cloned(token, repoId.owner, repoId.repo);
     };

--- a/src/operations/common/projectPersister.ts
+++ b/src/operations/common/projectPersister.ts
@@ -1,6 +1,0 @@
-import { ActionResult } from "../../internal/util/ActionResult";
-import { Project } from "../../project/Project";
-import { ProjectEditor } from "../edit/projectEditor";
-
-export type ProjectPersister<P extends Project = Project> =
-    (project: P, editor: ProjectEditor) => Promise<ActionResult<P>>;

--- a/src/operations/common/projectPersister.ts
+++ b/src/operations/common/projectPersister.ts
@@ -1,0 +1,6 @@
+import { ActionResult } from "../../internal/util/ActionResult";
+import { Project } from "../../project/Project";
+import { ProjectEditor } from "../edit/projectEditor";
+
+export type ProjectPersister<P extends Project = Project> =
+    (project: P, editor: ProjectEditor) => Promise<ActionResult<P>>;

--- a/src/operations/common/repoLoader.ts
+++ b/src/operations/common/repoLoader.ts
@@ -1,4 +1,3 @@
-
 import { Project } from "../../project/Project";
 import { RepoId } from "./RepoId";
 
@@ -6,4 +5,4 @@ import { RepoId } from "./RepoId";
  * A function that knows how to materialize a repo, whether
  * by cloning or other means
  */
-export type RepoLoader = (repoId: RepoId) => Promise<Project>;
+export type RepoLoader<P extends Project = Project> = (repoId: RepoId) => Promise<P>;

--- a/src/operations/common/repoUtils.ts
+++ b/src/operations/common/repoUtils.ts
@@ -1,0 +1,41 @@
+import { HandlerContext } from "../../HandlerContext";
+import { Project } from "../../project/Project";
+import { allReposInTeam } from "./allReposInTeamRepoFinder";
+import { defaultRepoLoader } from "./defaultRepoLoader";
+import { AllRepos, RepoFilter } from "./repoFilter";
+import { RepoFinder } from "./repoFinder";
+import { RepoId } from "./RepoId";
+import { RepoLoader } from "./repoLoader";
+
+/**
+ * Perform an action against all the given repos
+ * @param {HandlerContext} ctx
+ * @param {string} token
+ * @param {(p: Project) => Promise<R>} action
+ * @param {RepoFinder} repoFinder
+ * @param {} repoFilter
+ * @param {RepoLoader} repoLoader
+ * @return {Promise<R[]>}
+ */
+export function doWithAllRepos<R>(ctx: HandlerContext,
+                                  token: string,
+                                  action: (p: Project) => Promise<R>,
+                                  repoFinder: RepoFinder = allReposInTeam(),
+                                  repoFilter: RepoFilter = AllRepos,
+                                  repoLoader: RepoLoader = defaultRepoLoader(token)): Promise<R[]> {
+    return relevantRepos(ctx, repoFinder, repoFilter)
+        .then(ids =>
+            Promise.all(ids.map(id => repoLoader(id)
+                .then(action)),
+            ),
+        );
+}
+
+export function relevantRepos(ctx: HandlerContext,
+                              repoFinder: RepoFinder = allReposInTeam(),
+                              repoFilter: RepoFilter = AllRepos): Promise<RepoId[]> {
+
+    return repoFinder(ctx).then(rids =>
+        Promise.all(rids.map(rid => Promise.resolve(repoFilter(rid))
+            .then(relevant => relevant ? rid : undefined))));
+}

--- a/src/operations/edit/EditorCommandSupport.ts
+++ b/src/operations/edit/EditorCommandSupport.ts
@@ -4,7 +4,7 @@ import { HandlerResult } from "../../HandlerResult";
 import { Project } from "../../project/Project";
 import { LocalOrRemoteRepoOperation } from "../common/LocalOrRemoteRepoOperation";
 import { editAll } from "./editAll";
-import { EditInfo } from "./editModes";
+import { EditMode } from "./editModes";
 import { ProjectEditor } from "./projectEditor";
 
 /**
@@ -36,11 +36,11 @@ export abstract class EditorCommandSupport extends LocalOrRemoteRepoOperation im
     }
 
     /**
-     * Return PullRequestInfo or other identification for commit message
+     * Return PullRequest or other identification for commit message
      * @param {Project} p
-     * @return {EditInfo}
+     * @return {EditMode}
      */
-    public abstract editInfo(p: Project): EditInfo;
+    public abstract editInfo(p: Project): EditMode;
 
     /**
      * Invoked after parameters have been populated in the context of

--- a/src/operations/edit/EditorCommandSupport.ts
+++ b/src/operations/edit/EditorCommandSupport.ts
@@ -3,8 +3,8 @@ import { HandlerContext } from "../../HandlerContext";
 import { HandlerResult } from "../../HandlerResult";
 import { Project } from "../../project/Project";
 import { LocalOrRemoteRepoOperation } from "../common/LocalOrRemoteRepoOperation";
-import { EditInfo } from "./editModes";
 import { editAll } from "./editAll";
+import { EditInfo } from "./editModes";
 import { ProjectEditor } from "./projectEditor";
 
 /**

--- a/src/operations/edit/EditorCommandSupport.ts
+++ b/src/operations/edit/EditorCommandSupport.ts
@@ -26,7 +26,7 @@ export abstract class EditorCommandSupport extends LocalOrRemoteRepoOperation im
                         reposToEdit.map(r => {
                             if (this.local) {
                                 return load(r)
-                                    .then(p => projectEditor(r, p, context));
+                                    .then(p => projectEditor(p, context));
                             } else {
                                 return editUsingPullRequest(this.githubToken, context, r, projectEditor,
                                     // TODO customize PR config

--- a/src/operations/edit/EditorCommandSupport.ts
+++ b/src/operations/edit/EditorCommandSupport.ts
@@ -1,9 +1,10 @@
 import { HandleCommand } from "../../HandleCommand";
 import { HandlerContext } from "../../HandlerContext";
 import { HandlerResult } from "../../HandlerResult";
-import { logger } from "../../internal/util/logger";
+import { Project } from "../../project/Project";
 import { LocalOrRemoteRepoOperation } from "../common/LocalOrRemoteRepoOperation";
-import { editUsingPullRequest, PullRequestInfo } from "../support/editorUtils";
+import { EditInfo } from "./editModes";
+import { editAll } from "./editAll";
 import { ProjectEditor } from "./projectEditor";
 
 /**
@@ -13,43 +14,39 @@ import { ProjectEditor } from "./projectEditor";
 export abstract class EditorCommandSupport extends LocalOrRemoteRepoOperation implements HandleCommand {
 
     public handle(context: HandlerContext): Promise<HandlerResult> {
-        const load = this.repoLoader();
-        const rawPe = this.projectEditor(context);
-        const projectEditorPromise: Promise<ProjectEditor<any>> = Promise.resolve(rawPe);
+        // Save us from this
+        const token = this.githubToken;
+        const repoFinder = this.repoFinder();
+        const repoFilter = this.repoFilter;
+        const repoLoader = this.repoLoader();
+        const editInfoFactory = this.editInfo;
 
-        return projectEditorPromise.then(projectEditor => {
-            return this.repoFinder()(context)
-                .then(repoIds => {
-                    const reposToEdit = repoIds.filter(this.repoFilter);
-                    logger.info("Repos to edit are " + reposToEdit.map(r => r.repo).join(","));
-                    const editOps: Array<Promise<any>> =
-                        reposToEdit.map(r => {
-                            if (this.local) {
-                                return load(r)
-                                    .then(p => projectEditor(p, context));
-                            } else {
-                                return editUsingPullRequest(this.githubToken, context, r, projectEditor,
-                                    // TODO customize PR config
-                                    new PullRequestInfo("add-license", "Added license"));
-                            }
-                        });
-                    return Promise.all(editOps)
-                        .then(_ => {
-                            return {
-                                code: 0,
-                                reposEdited: reposToEdit.length,
-                                reposSeen: repoIds.length,
-                            };
-                        });
-                });
-        });
+        return Promise.resolve(this.projectEditor(context))
+            .then(pe =>
+                editAll(context, token, pe,
+                    editInfoFactory,
+                    repoFinder, repoFilter, repoLoader))
+            .then(edits => {
+                return {
+                    code: 0,
+                    reposEdited: edits.filter(e => e.edited).length,
+                    reposSeen: edits.length,
+                };
+            });
     }
+
+    /**
+     * Return PullRequestInfo or other identification for commit message
+     * @param {Project} p
+     * @return {EditInfo}
+     */
+    public abstract editInfo(p: Project): EditInfo;
 
     /**
      * Invoked after parameters have been populated in the context of
      * a particular operation. Return an actual editor or a promise,
      * if the editor needs to be created based on the current context.
      */
-    public abstract projectEditor(context: HandlerContext): ProjectEditor<any> | Promise<ProjectEditor<any>>;
+    public abstract projectEditor(context: HandlerContext): ProjectEditor | Promise<ProjectEditor>;
 
 }

--- a/src/operations/edit/editAll.ts
+++ b/src/operations/edit/editAll.ts
@@ -1,35 +1,38 @@
 import { HandlerContext } from "../../HandlerContext";
 import { ActionResult } from "../../internal/util/ActionResult";
 import { GitProject } from "../../project/git/GitProject";
+import { Project } from "../../project/Project";
 import { allReposInTeam } from "../common/allReposInTeamRepoFinder";
 import { defaultRepoLoader } from "../common/defaultRepoLoader";
-import { ProjectPersister } from "../common/projectPersister";
 import { AllRepos, RepoFilter } from "../common/repoFilter";
 import { RepoFinder } from "../common/repoFinder";
 import { RepoLoader } from "../common/repoLoader";
 import { doWithAllRepos } from "../common/repoUtils";
-import { ProjectEditor } from "./projectEditor";
+import { EditInfo, EditInfoFactory, isEditInfo } from "./editModes";
+import { loadAndEditRepo } from "../support/editorUtils";
+import { EditResult, ProjectEditor } from "./projectEditor";
 
 /**
- * Edit all the given repos
+ * Edit all the given repos with the given editor
  * @param {HandlerContext} ctx
  * @param {string} token
  * @param {ProjectEditor} editor
+ * @param editInfo: EditInfo determines how the edits should be applied.
+ * Factory allows us to use different branches if necessary
  * @param {RepoFinder} repoFinder
  * @param {} repoFilter
  * @param {RepoLoader} repoLoader
- * @param {ProjectPersister<GitProject>} pp
  * @return {Promise<Array<ActionResult<GitProject>>>}
  */
 export function editAll<R>(ctx: HandlerContext,
                            token: string,
                            editor: ProjectEditor,
-                           pp: ProjectPersister<GitProject>,
+                           editInfo: EditInfo | EditInfoFactory,
                            repoFinder: RepoFinder = allReposInTeam(),
                            repoFilter: RepoFilter = AllRepos,
-                           repoLoader: RepoLoader = defaultRepoLoader(token),
-                            ): Promise<Array<ActionResult<GitProject>>> {
-    const actAndPersist = p =>
-        pp(p, editor);
-    return doWithAllRepos(ctx, token, actAndPersist, repoFinder, repoFilter, repoLoader);
+                           repoLoader: RepoLoader = defaultRepoLoader(token)): Promise<EditResult[]> {
+    const ei: (project: Project) => EditInfo = p =>
+        isEditInfo(editInfo) ? editInfo : editInfo(p);
+    const edit = (p: Project) => loadAndEditRepo(token, ctx, p, editor, ei(p));
+    return doWithAllRepos<EditResult>(ctx, token, edit, repoFinder, repoFilter, repoLoader);
 }

--- a/src/operations/edit/editAll.ts
+++ b/src/operations/edit/editAll.ts
@@ -9,7 +9,7 @@ import { RepoFinder } from "../common/repoFinder";
 import { RepoLoader } from "../common/repoLoader";
 import { doWithAllRepos } from "../common/repoUtils";
 import { loadAndEditRepo } from "../support/editorUtils";
-import { EditInfo, EditInfoFactory, isEditInfo, toEditInfoFactory } from "./editModes";
+import { EditMode, EditModeFactory, isEditMode, toEditModeFactory } from "./editModes";
 import { EditResult, ProjectEditor } from "./projectEditor";
 
 /**
@@ -17,7 +17,7 @@ import { EditResult, ProjectEditor } from "./projectEditor";
  * @param {HandlerContext} ctx
  * @param {string} token
  * @param {ProjectEditor} editor
- * @param editInfo: EditInfo determines how the edits should be applied.
+ * @param editInfo: EditMode determines how the edits should be applied.
  * Factory allows us to use different branches if necessary
  * @param {RepoFinder} repoFinder
  * @param {} repoFilter
@@ -27,10 +27,10 @@ import { EditResult, ProjectEditor } from "./projectEditor";
 export function editAll<R>(ctx: HandlerContext,
                            token: string,
                            editor: ProjectEditor,
-                           editInfo: EditInfo | EditInfoFactory,
+                           editInfo: EditMode | EditModeFactory,
                            repoFinder: RepoFinder = allReposInTeam(),
                            repoFilter: RepoFilter = AllRepos,
                            repoLoader: RepoLoader = defaultRepoLoader(token)): Promise<EditResult[]> {
-    const edit = (p: Project) => loadAndEditRepo(token, ctx, p, editor, toEditInfoFactory(editInfo)(p));
+    const edit = (p: Project) => loadAndEditRepo(token, ctx, p, editor, toEditModeFactory(editInfo)(p));
     return doWithAllRepos<EditResult>(ctx, token, edit, repoFinder, repoFilter, repoLoader);
 }

--- a/src/operations/edit/editAll.ts
+++ b/src/operations/edit/editAll.ts
@@ -9,7 +9,7 @@ import { RepoFinder } from "../common/repoFinder";
 import { RepoLoader } from "../common/repoLoader";
 import { doWithAllRepos } from "../common/repoUtils";
 import { loadAndEditRepo } from "../support/editorUtils";
-import { EditInfo, EditInfoFactory, isEditInfo } from "./editModes";
+import { EditInfo, EditInfoFactory, isEditInfo, toEditInfoFactory } from "./editModes";
 import { EditResult, ProjectEditor } from "./projectEditor";
 
 /**
@@ -31,8 +31,6 @@ export function editAll<R>(ctx: HandlerContext,
                            repoFinder: RepoFinder = allReposInTeam(),
                            repoFilter: RepoFilter = AllRepos,
                            repoLoader: RepoLoader = defaultRepoLoader(token)): Promise<EditResult[]> {
-    const ei: (project: Project) => EditInfo = p =>
-        isEditInfo(editInfo) ? editInfo : editInfo(p);
-    const edit = (p: Project) => loadAndEditRepo(token, ctx, p, editor, ei(p));
+    const edit = (p: Project) => loadAndEditRepo(token, ctx, p, editor, toEditInfoFactory(editInfo)(p));
     return doWithAllRepos<EditResult>(ctx, token, edit, repoFinder, repoFilter, repoLoader);
 }

--- a/src/operations/edit/editAll.ts
+++ b/src/operations/edit/editAll.ts
@@ -1,0 +1,35 @@
+import { HandlerContext } from "../../HandlerContext";
+import { ActionResult } from "../../internal/util/ActionResult";
+import { GitProject } from "../../project/git/GitProject";
+import { allReposInTeam } from "../common/allReposInTeamRepoFinder";
+import { defaultRepoLoader } from "../common/defaultRepoLoader";
+import { ProjectPersister } from "../common/projectPersister";
+import { AllRepos, RepoFilter } from "../common/repoFilter";
+import { RepoFinder } from "../common/repoFinder";
+import { RepoLoader } from "../common/repoLoader";
+import { doWithAllRepos } from "../common/repoUtils";
+import { ProjectEditor } from "./projectEditor";
+
+/**
+ * Edit all the given repos
+ * @param {HandlerContext} ctx
+ * @param {string} token
+ * @param {ProjectEditor} editor
+ * @param {RepoFinder} repoFinder
+ * @param {} repoFilter
+ * @param {RepoLoader} repoLoader
+ * @param {ProjectPersister<GitProject>} pp
+ * @return {Promise<Array<ActionResult<GitProject>>>}
+ */
+export function editAll<R>(ctx: HandlerContext,
+                           token: string,
+                           editor: ProjectEditor,
+                           pp: ProjectPersister<GitProject>,
+                           repoFinder: RepoFinder = allReposInTeam(),
+                           repoFilter: RepoFilter = AllRepos,
+                           repoLoader: RepoLoader = defaultRepoLoader(token),
+                            ): Promise<Array<ActionResult<GitProject>>> {
+    const actAndPersist = p =>
+        pp(p, editor);
+    return doWithAllRepos(ctx, token, actAndPersist, repoFinder, repoFilter, repoLoader);
+}

--- a/src/operations/edit/editAll.ts
+++ b/src/operations/edit/editAll.ts
@@ -8,8 +8,8 @@ import { AllRepos, RepoFilter } from "../common/repoFilter";
 import { RepoFinder } from "../common/repoFinder";
 import { RepoLoader } from "../common/repoLoader";
 import { doWithAllRepos } from "../common/repoUtils";
-import { EditInfo, EditInfoFactory, isEditInfo } from "./editModes";
 import { loadAndEditRepo } from "../support/editorUtils";
+import { EditInfo, EditInfoFactory, isEditInfo } from "./editModes";
 import { EditResult, ProjectEditor } from "./projectEditor";
 
 /**

--- a/src/operations/edit/editModes.ts
+++ b/src/operations/edit/editModes.ts
@@ -1,12 +1,21 @@
-/**
- * Basic information for any edit
- */
 
 import { Project } from "../../project/Project";
 import { EditResult } from "./projectEditor";
 
+/**
+ * Used to determine EditInfo on a per project basis,
+ * for example if we want to use a different branch name on different repos
+ */
 export type EditInfoFactory = (p: Project) => EditInfo;
 
+export function toEditInfoFactory(ei: EditInfo | EditInfoFactory): EditInfoFactory {
+    return p => isEditInfo(ei) ? ei : ei(p);
+}
+
+/**
+ * Root interface for information on how to apply an edit:
+ * E.g via a PR or commit to master
+ */
 export interface EditInfo {
     commitMessage: string;
 }

--- a/src/operations/edit/editModes.ts
+++ b/src/operations/edit/editModes.ts
@@ -1,0 +1,58 @@
+/**
+ * Basic information for any edit
+ */
+
+import { Project } from "../../project/Project";
+import { EditResult } from "./projectEditor";
+
+export type EditInfoFactory = (p: Project) => EditInfo;
+
+export interface EditInfo {
+    commitMessage: string;
+}
+
+export function isEditInfo(ei: any): ei is EditInfo {
+    return !!ei.commitMessage;
+}
+
+/**
+ * Represents a commit to a project
+ */
+export interface CommitInfo extends EditInfo {
+    branch: string;
+    commitMessage: string;
+}
+
+export function isCommitInfo(ei: EditInfo): ei is CommitInfo {
+    const maybeCi = ei as CommitInfo;
+    return !!maybeCi.branch && !!maybeCi.commitMessage;
+}
+
+/**
+ * Captures extra steps that must go into raising a PR
+ */
+export class PullRequestInfo implements CommitInfo {
+    constructor(public branch: string,
+                public title: string,
+                public body: string = title,
+                public commitMessage: string = title) {
+    }
+}
+
+export function isPullRequestInfo(ei: EditInfo): ei is PullRequestInfo {
+    const maybePr = ei as PullRequestInfo;
+    return !!maybePr.branch && !!maybePr.body && !!maybePr.title;
+}
+
+/**
+ * Use for edit modes that require custom persistence
+ */
+export interface CustomExecutionEditInfo extends EditInfo {
+
+    edit(p: Project): Promise<EditResult>;
+}
+
+export function isCustomExecutionEditInfo(ei: EditInfo): ei is CustomExecutionEditInfo {
+    const maybeCei = ei as CustomExecutionEditInfo;
+    return !!maybeCei.edit;
+}

--- a/src/operations/edit/editModes.ts
+++ b/src/operations/edit/editModes.ts
@@ -3,65 +3,66 @@ import { Project } from "../../project/Project";
 import { EditResult } from "./projectEditor";
 
 /**
- * Used to determine EditInfo on a per project basis,
+ * Used to determine EditMode on a per project basis,
  * for example if we want to use a different branch name on different repos
  */
-export type EditInfoFactory = (p: Project) => EditInfo;
+export type EditModeFactory = (p: Project) => EditMode;
 
-export function toEditInfoFactory(ei: EditInfo | EditInfoFactory): EditInfoFactory {
-    return p => isEditInfo(ei) ? ei : ei(p);
+export function toEditModeFactory(em: EditMode | EditModeFactory): EditModeFactory {
+    return p => isEditMode(em) ? em : em(p);
 }
 
 /**
  * Root interface for information on how to apply an edit:
  * E.g via a PR or commit to master
  */
-export interface EditInfo {
-    commitMessage: string;
+export interface EditMode {
+
+    message: string;
 }
 
-export function isEditInfo(ei: any): ei is EditInfo {
-    return !!ei.commitMessage;
+export function isEditMode(em: any): em is EditMode {
+    return !!em.message;
 }
 
 /**
  * Represents a commit to a project
  */
-export interface CommitInfo extends EditInfo {
+export interface BranchCommit extends EditMode {
     branch: string;
-    commitMessage: string;
 }
 
-export function isCommitInfo(ei: EditInfo): ei is CommitInfo {
-    const maybeCi = ei as CommitInfo;
-    return !!maybeCi.branch && !!maybeCi.commitMessage;
+export function isBranchCommit(em: EditMode): em is BranchCommit {
+    const maybeBc = em as BranchCommit;
+    return !!maybeBc.branch && !!maybeBc.message;
 }
 
 /**
  * Captures extra steps that must go into raising a PR
  */
-export class PullRequestInfo implements CommitInfo {
+export class PullRequest implements BranchCommit {
+
     constructor(public branch: string,
                 public title: string,
                 public body: string = title,
-                public commitMessage: string = title) {
+                public message: string = title) {
     }
 }
 
-export function isPullRequestInfo(ei: EditInfo): ei is PullRequestInfo {
-    const maybePr = ei as PullRequestInfo;
+export function isPullRequest(em: EditMode): em is PullRequest {
+    const maybePr = em as PullRequest;
     return !!maybePr.branch && !!maybePr.body && !!maybePr.title;
 }
 
 /**
  * Use for edit modes that require custom persistence
  */
-export interface CustomExecutionEditInfo extends EditInfo {
+export interface CustomExecutionEditMode extends EditMode {
 
     edit(p: Project): Promise<EditResult>;
 }
 
-export function isCustomExecutionEditInfo(ei: EditInfo): ei is CustomExecutionEditInfo {
-    const maybeCei = ei as CustomExecutionEditInfo;
+export function isCustomExecutionEditMode(ei: EditMode): ei is CustomExecutionEditMode {
+    const maybeCei = ei as CustomExecutionEditMode;
     return !!maybeCei.edit;
 }

--- a/src/operations/edit/projectEditor.ts
+++ b/src/operations/edit/projectEditor.ts
@@ -1,6 +1,6 @@
 import { HandlerContext } from "../../HandlerContext";
+import { ActionResult } from "../../internal/util/ActionResult";
 import { Project } from "../../project/Project";
-import { RepoId } from "../common/RepoId";
 
 /**
  * Modifies the given project, returning information about the modification.
@@ -11,10 +11,18 @@ export type ProjectEditor<ER extends EditResult = EditResult> =
 /**
  * Result of editing a project. More information may be added by instances.
  */
-export interface EditResult {
+export interface EditResult<P extends Project = Project> extends ActionResult<P> {
 
     /**
      * Whether or not this project was edited
      */
-    edited: boolean;
+    readonly edited: boolean;
+}
+
+export function successfulEdit<P extends Project>(p: P, edited: boolean = true): EditResult<P> {
+    return {
+        target: p,
+        success: true,
+        edited,
+    };
 }

--- a/src/operations/edit/projectEditor.ts
+++ b/src/operations/edit/projectEditor.ts
@@ -6,7 +6,7 @@ import { RepoId } from "../common/RepoId";
  * Modifies the given project, returning information about the modification.
  */
 export type ProjectEditor<ER extends EditResult = EditResult> =
-    (id: RepoId, p: Project, context: HandlerContext) => Promise<ER>;
+    (p: Project, context: HandlerContext) => Promise<ER>;
 
 /**
  * Result of editing a project. More information may be added by instances.

--- a/src/operations/review/ReviewResult.ts
+++ b/src/operations/review/ReviewResult.ts
@@ -34,7 +34,7 @@ export interface ProjectReview {
  * The result of reviewing many projects: For example,
  * all the projects in an org
  */
-export interface ReviewResult<T extends ProjectReview> extends HandlerResult {
+export interface ReviewResult<T extends ProjectReview = ProjectReview> extends HandlerResult {
 
     projectsReviewed: number;
 

--- a/src/operations/review/ReviewerCommandSupport.ts
+++ b/src/operations/review/ReviewerCommandSupport.ts
@@ -12,9 +12,8 @@ import { ProjectReview, ReviewResult } from "./ReviewResult";
  * Support for reviewing multiple projects
  * Subclasses should have @CommandHandler annotation
  */
-export abstract class ReviewerCommandSupport<
-        RR extends ReviewResult<PR> = ReviewResult<PR>,
-        PR extends ProjectReview = ProjectReview>
+export abstract class ReviewerCommandSupport<RR extends ReviewResult<PR> = ReviewResult<PR>,
+    PR extends ProjectReview = ProjectReview>
     extends LocalOrRemoteRepoOperation
     implements HandleCommand {
 
@@ -42,7 +41,7 @@ export abstract class ReviewerCommandSupport<
                             logger.info("Attempting to review %s", JSON.stringify(id));
                             return load(id)
                                 .then(p => {
-                                    return projectReviewer(id, p, context);
+                                    return projectReviewer(p, context);
                                 })
                                 .then(review => {
                                     // Don't attempt to raise issues when reviewing a local repo
@@ -50,7 +49,7 @@ export abstract class ReviewerCommandSupport<
                                         review.comments && review.comments.length > 0) {
                                         return raiseIssue(this.githubToken,
                                             review.repoId, {
-                                                title: "Outdated Spring Boot version",
+                                                title: "Atomist review comments",
                                                 body: review.comments.map(c => c.comment).join("\n"),
                                             })
                                             .then(_ => review);

--- a/src/operations/review/projectReviewer.ts
+++ b/src/operations/review/projectReviewer.ts
@@ -1,10 +1,9 @@
 import { HandlerContext } from "../../HandlerContext";
 import { Project } from "../../project/Project";
-import { RepoId } from "../common/RepoId";
 import { ProjectReview } from "./ReviewResult";
 
 /**
- * Function that can review a project
+ * Function that can review projects
  */
 export type ProjectReviewer<RR extends ProjectReview = ProjectReview> =
-    (id: RepoId, p: Project, context: HandlerContext) => Promise<RR>;
+    (p: Project, context: HandlerContext) => Promise<RR>;

--- a/src/operations/review/reviewAll.ts
+++ b/src/operations/review/reviewAll.ts
@@ -1,0 +1,55 @@
+import { HandlerContext } from "../../HandlerContext";
+import { ActionResult } from "../../internal/util/ActionResult";
+import { GitProject } from "../../project/git/GitProject";
+import { allReposInTeam } from "../common/allReposInTeamRepoFinder";
+import { defaultRepoLoader } from "../common/defaultRepoLoader";
+import { AllRepos, RepoFilter } from "../common/repoFilter";
+import { RepoFinder } from "../common/repoFinder";
+import { RepoLoader } from "../common/repoLoader";
+import { doWithAllRepos } from "../common/repoUtils";
+import { ProjectReviewer } from "./projectReviewer";
+import { ProjectReview, ReviewResult } from "./ReviewResult";
+
+/**
+ * Review all the repos
+ * @param {HandlerContext} ctx
+ * @param {string} token
+ * @param {ProjectReviewer} reviewer
+ * @param {RepoFinder} repoFinder
+ * @param {} repoFilter
+ * @param {RepoLoader} repoLoader
+ * @return {Promise<Array<ActionResult<GitProject>>>}
+ */
+export function reviewAll<R>(ctx: HandlerContext,
+                             token: string,
+                             reviewer: ProjectReviewer,
+                             repoFinder: RepoFinder = allReposInTeam(),
+                             repoFilter: RepoFilter = AllRepos,
+                             repoLoader: RepoLoader = defaultRepoLoader(token)): Promise<ProjectReview[]> {
+    return doWithAllRepos(ctx, token, p => reviewer(p, ctx), repoFinder, repoFilter, repoLoader);
+}
+
+export function review<R>(ctx: HandlerContext,
+                          token: string,
+                          reviewer: ProjectReviewer,
+                          repoFinder: RepoFinder = allReposInTeam(),
+                          repoFilter: RepoFilter = AllRepos,
+                          repoLoader: RepoLoader = defaultRepoLoader(token)): Promise<ReviewResult> {
+    let projectsReviewed = 0;
+    const countingRepoFilter: RepoFilter = id => {
+        const include = repoFilter(id);
+        if (include) {
+            ++projectsReviewed;
+        }
+        return include;
+    };
+    return doWithAllRepos(ctx, token, p => reviewer(p, ctx),
+        repoFinder, countingRepoFilter, repoLoader)
+        .then(projectReviews => {
+            return {
+                projectReviews,
+                projectsReviewed,
+                code: 0,
+            };
+        });
+}

--- a/src/operations/support/contextUtils.ts
+++ b/src/operations/support/contextUtils.ts
@@ -1,13 +1,12 @@
-/**
- * Convenient function to return a success result if we are able to send messages
- * recorded in context MessageClient
- * @param ctx handler context
- * @return {Promise<TResult2|{code: number}>}
- */
 
 import { HandlerContext } from "../../HandlerContext";
 import { HandlerResult } from "../../HandlerResult";
 
+/**
+ * Convenient function to return a success result if we are able to send messages
+ * recorded in context MessageClient
+ * @param ctx handler context
+ */
 export function sendMessages(ctx: HandlerContext): Promise<HandlerResult> {
     return ctx.messageClient.flush()
         .then(_ => {

--- a/src/operations/support/editorUtils.ts
+++ b/src/operations/support/editorUtils.ts
@@ -16,20 +16,19 @@ import { ProjectEditor } from "../edit/projectEditor";
 export function editUsingPullRequest(token: string,
                                      context: HandlerContext,
                                      repo: RepoId,
-                                     editor: ProjectEditor<any>,
+                                     editor: ProjectEditor,
                                      pr: PullRequestInfo): Promise<ActionResult<GitProject>> {
     console.log("Editing project " + JSON.stringify(repo));
     return GitCommandGitProject.cloned(token, repo.owner, repo.repo)
-        .then(gp => editProjectUsingPullRequest(context, repo, gp, editor, pr));
+        .then(gp => editProjectUsingPullRequest(context, gp, editor, pr));
 }
 
 export function editProjectUsingPullRequest(context: HandlerContext,
-                                            repo: RepoId,
                                             gp: GitProject,
                                             editor: ProjectEditor,
                                             pr: PullRequestInfo): Promise<ActionResult<GitProject>> {
 
-    return editor(repo, gp, context)
+    return editor(gp, context)
         .then(r => r.edited ?
             raisePr(gp, pr) :
             {
@@ -39,12 +38,11 @@ export function editProjectUsingPullRequest(context: HandlerContext,
 }
 
 export function editProjectUsingBranch(context: HandlerContext,
-                                       repo: RepoId,
                                        gp: GitProject,
                                        editor: ProjectEditor,
                                        ci: CommitInfo): Promise<ActionResult<GitProject>> {
 
-    return editor(repo, gp, context)
+    return editor(gp, context)
         .then(r => r.edited ?
             createAndPushBranch(gp, ci) :
             {

--- a/src/operations/support/editorUtils.ts
+++ b/src/operations/support/editorUtils.ts
@@ -1,32 +1,48 @@
 import { HandlerContext } from "../../HandlerContext";
-import { ActionResult } from "../../internal/util/ActionResult";
-import { GitCommandGitProject } from "../../project/git/GitCommandGitProject";
 import { GitProject } from "../../project/git/GitProject";
-import { RepoId } from "../common/RepoId";
-import { ProjectEditor } from "../edit/projectEditor";
+import { Project } from "../../project/Project";
+import { defaultRepoLoader } from "../common/defaultRepoLoader";
+import { isRepoId, RepoId } from "../common/RepoId";
+import { RepoLoader } from "../common/repoLoader";
+import { EditResult, ProjectEditor, successfulEdit } from "../edit/projectEditor";
+import {
+    CommitInfo, EditInfo, isCommitInfo, isCustomExecutionEditInfo, isPullRequestInfo,
+    PullRequestInfo,
+} from "../edit/editModes";
 
 /**
- * Edit a GitHub project using a PR
+ * Edit a GitHub project using a PR or branch
  * @param token GitHub token
  * @param context handler context for this operation
  * @param repo repo id
  * @param editor editor to use
- * @param pr structure of the PR
+ * @param repoLoader repo loading strategy
+ * @param ei how to persist the edit
  */
-export function editUsingPullRequest(token: string,
-                                     context: HandlerContext,
-                                     repo: RepoId,
-                                     editor: ProjectEditor,
-                                     pr: PullRequestInfo): Promise<ActionResult<GitProject>> {
-    console.log("Editing project " + JSON.stringify(repo));
-    return GitCommandGitProject.cloned(token, repo.owner, repo.repo)
-        .then(gp => editProjectUsingPullRequest(context, gp, editor, pr));
+export function loadAndEditRepo(token: string,
+                                context: HandlerContext,
+                                repo: RepoId | Project,
+                                editor: ProjectEditor,
+                                ei: EditInfo,
+                                repoLoader: RepoLoader =
+                                    defaultRepoLoader(token)): Promise<EditResult> {
+    const loadRepo: Promise<Project> = isRepoId(repo) ? repoLoader(repo) : Promise.resolve(repo);
+    if (isPullRequestInfo(ei)) {
+        return loadRepo.then(gp => editProjectUsingPullRequest(context, gp as GitProject, editor, ei));
+    } else if (isCommitInfo(ei)) {
+        return loadRepo.then(gp => editProjectUsingBranch(context, gp as GitProject, editor, ei));
+    } else if (isCustomExecutionEditInfo(ei)) {
+        return loadRepo.then(ei.edit);
+    } else {
+        // No edit to do
+        return loadRepo.then(gp => successfulEdit(gp, true));
+    }
 }
 
 export function editProjectUsingPullRequest(context: HandlerContext,
                                             gp: GitProject,
                                             editor: ProjectEditor,
-                                            pr: PullRequestInfo): Promise<ActionResult<GitProject>> {
+                                            pr: PullRequestInfo): Promise<EditResult> {
 
     return editor(gp, context)
         .then(r => r.edited ?
@@ -34,13 +50,14 @@ export function editProjectUsingPullRequest(context: HandlerContext,
             {
                 target: gp,
                 success: false,
+                edited: false,
             });
 }
 
 export function editProjectUsingBranch(context: HandlerContext,
                                        gp: GitProject,
                                        editor: ProjectEditor,
-                                       ci: CommitInfo): Promise<ActionResult<GitProject>> {
+                                       ci: CommitInfo): Promise<EditResult> {
 
     return editor(gp, context)
         .then(r => r.edited ?
@@ -48,6 +65,7 @@ export function editProjectUsingBranch(context: HandlerContext,
             {
                 target: gp,
                 success: false,
+                edited: false,
             });
 }
 
@@ -56,10 +74,11 @@ export function editProjectUsingBranch(context: HandlerContext,
  * @param {GitProject} gp
  * @param {CommitInfo} ci
  */
-export function createAndPushBranch(gp: GitProject, ci: CommitInfo): Promise<ActionResult<GitProject>> {
+export function createAndPushBranch(gp: GitProject, ci: CommitInfo): Promise<EditResult> {
     return gp.createBranch(ci.branch)
         .then(x => gp.commit(ci.commitMessage))
-        .then(x => gp.push());
+        .then(x => gp.push())
+        .then(r => successfulEdit(r.target, true));
 }
 
 /**
@@ -67,22 +86,10 @@ export function createAndPushBranch(gp: GitProject, ci: CommitInfo): Promise<Act
  * @param {GitProject} gp
  * @param {PullRequestInfo} pr
  */
-export function raisePr(gp: GitProject, pr: PullRequestInfo): Promise<ActionResult<GitProject>> {
+export function raisePr(gp: GitProject, pr: PullRequestInfo): Promise<EditResult> {
     return createAndPushBranch(gp, pr)
         .then(x => {
-            return gp.raisePullRequest(pr.title, pr.body);
+            return gp.raisePullRequest(pr.title, pr.body)
+                .then(r => successfulEdit(gp));
         });
-}
-
-export interface CommitInfo {
-    branch: string;
-    commitMessage: string;
-}
-
-export class PullRequestInfo implements CommitInfo {
-    constructor(public branch: string,
-                public title: string,
-                public body: string = title,
-                public commitMessage: string = title) {
-    }
 }

--- a/src/operations/support/editorUtils.ts
+++ b/src/operations/support/editorUtils.ts
@@ -4,11 +4,11 @@ import { Project } from "../../project/Project";
 import { defaultRepoLoader } from "../common/defaultRepoLoader";
 import { isRepoId, RepoId } from "../common/RepoId";
 import { RepoLoader } from "../common/repoLoader";
-import { EditResult, ProjectEditor, successfulEdit } from "../edit/projectEditor";
 import {
     CommitInfo, EditInfo, isCommitInfo, isCustomExecutionEditInfo, isPullRequestInfo,
     PullRequestInfo,
 } from "../edit/editModes";
+import { EditResult, ProjectEditor, successfulEdit } from "../edit/projectEditor";
 
 /**
  * Edit a GitHub project using a PR or branch

--- a/src/project/git/GitCommandGitProject.ts
+++ b/src/project/git/GitCommandGitProject.ts
@@ -12,8 +12,9 @@ import { CommandResult, runCommand } from "../../internal/util/commandLine";
 import { logger } from "../../internal/util/logger";
 import { hideString } from "../../internal/util/string";
 import { RepoId, SimpleRepoId } from "../../operations/common/RepoId";
+import { PullRequestInfo } from "../../operations/edit/editModes";
 import { NodeFsLocalProject } from "../local/NodeFsLocalProject";
-import { GitProject, PullRequestInfo } from "./GitProject";
+import { GitProject } from "./GitProject";
 
 export const GitHubBase = "https://api.github.com";
 
@@ -257,14 +258,12 @@ export function cloneEditAndPush(token: string,
                                  owner: string,
                                  name: string,
                                  doWithProject: (Project) => void,
-                                 commitMessage: string,
-                                 branch?: string,
                                  pr?: PullRequestInfo): Promise<ActionResult<GitCommandGitProject>> {
     return GitCommandGitProject.cloned(token, owner, name).then(gp => {
         doWithProject(gp);
-        const start: Promise<any> = branch ? gp.createBranch(branch) : Promise.resolve();
+        const start: Promise<any> = pr.branch ? gp.createBranch(pr.branch) : Promise.resolve();
         return start
-            .then(_ => gp.commit(commitMessage))
+            .then(_ => gp.commit(pr.commitMessage))
             .then(_ => gp.push())
             .then(x => {
                 if (pr) {
@@ -288,7 +287,6 @@ export function cloneEditAndPush(token: string,
  * @param user
  * @param repo
  * @param branch
- * @return {Promise<TResult2|LocalProject>|PromiseLike<TResult2|LocalProject>}
  */
 function clone(token: string,
                user: string,

--- a/src/project/git/GitCommandGitProject.ts
+++ b/src/project/git/GitCommandGitProject.ts
@@ -12,7 +12,7 @@ import { CommandResult, runCommand } from "../../internal/util/commandLine";
 import { logger } from "../../internal/util/logger";
 import { hideString } from "../../internal/util/string";
 import { RepoId, SimpleRepoId } from "../../operations/common/RepoId";
-import { PullRequestInfo } from "../../operations/edit/editModes";
+import { PullRequest } from "../../operations/edit/editModes";
 import { NodeFsLocalProject } from "../local/NodeFsLocalProject";
 import { GitProject } from "./GitProject";
 
@@ -258,12 +258,12 @@ export function cloneEditAndPush(token: string,
                                  owner: string,
                                  name: string,
                                  doWithProject: (Project) => void,
-                                 pr?: PullRequestInfo): Promise<ActionResult<GitCommandGitProject>> {
+                                 pr?: PullRequest): Promise<ActionResult<GitCommandGitProject>> {
     return GitCommandGitProject.cloned(token, owner, name).then(gp => {
         doWithProject(gp);
         const start: Promise<any> = pr.branch ? gp.createBranch(pr.branch) : Promise.resolve();
         return start
-            .then(_ => gp.commit(pr.commitMessage))
+            .then(_ => gp.commit(pr.message))
             .then(_ => gp.push())
             .then(x => {
                 if (pr) {

--- a/src/project/git/GitProject.ts
+++ b/src/project/git/GitProject.ts
@@ -94,14 +94,3 @@ export interface GitProject extends LocalProject {
     createBranch(name: string): Promise<ActionResult<this>>;
 
 }
-
-/**
- * Information used in creating a GitHub pull request.
- */
-export interface PullRequestInfo {
-
-    title: string;
-
-    body: string;
-
-}

--- a/test/operations/edit/LocalEditorTest.ts
+++ b/test/operations/edit/LocalEditorTest.ts
@@ -9,7 +9,7 @@ describe("Local editing", () => {
     it("should not edit with no op editor", done => {
         const project = tempProject();
         const editor: ProjectEditor<EditResult> = p => Promise.resolve({ edited: false });
-        editor(null, project, null)
+        editor(project, null)
             .then(r => {
                 assert(!r.edited);
                 done();
@@ -18,11 +18,11 @@ describe("Local editing", () => {
 
     it("should edit on disk with real editor", done => {
         const project = tempProject();
-        const editor: ProjectEditor<EditResult> = (id, p) => {
+        const editor: ProjectEditor<EditResult> = p => {
             p.addFileSync("thing", "1");
             return Promise.resolve({ edited: true });
         };
-        editor(null, project, null)
+        editor(project, null)
             .then(r => {
                 assert(r.edited);
                 // Reload project

--- a/test/operations/edit/LocalEditorTest.ts
+++ b/test/operations/edit/LocalEditorTest.ts
@@ -1,14 +1,14 @@
 import * as fs from "fs";
 import "mocha";
 import * as assert from "power-assert";
-import { EditResult, ProjectEditor } from "../../../src/operations/edit/projectEditor";
+import { ProjectEditor, successfulEdit } from "../../../src/operations/edit/projectEditor";
 import { tempProject } from "../../project/utils";
 
 describe("Local editing", () => {
 
     it("should not edit with no op editor", done => {
         const project = tempProject();
-        const editor: ProjectEditor<EditResult> = p => Promise.resolve({ edited: false });
+        const editor: ProjectEditor = p => Promise.resolve(successfulEdit(p, false));
         editor(project, null)
             .then(r => {
                 assert(!r.edited);
@@ -18,9 +18,9 @@ describe("Local editing", () => {
 
     it("should edit on disk with real editor", done => {
         const project = tempProject();
-        const editor: ProjectEditor<EditResult> = p => {
+        const editor: ProjectEditor = p => {
             p.addFileSync("thing", "1");
-            return Promise.resolve({ edited: true });
+            return Promise.resolve(successfulEdit(p, true));
         };
         editor(project, null)
             .then(r => {

--- a/test/operations/edit/editAllTest.ts
+++ b/test/operations/edit/editAllTest.ts
@@ -4,8 +4,8 @@ import * as assert from "power-assert";
 
 import { fromListRepoFinder, fromListRepoLoader } from "../../../src/operations/common/fromProjectList";
 import { editAll } from "../../../src/operations/edit/editAll";
-import { ProjectEditor, successfulEdit } from "../../../src/operations/edit/projectEditor";
 import { CustomExecutionEditInfo } from "../../../src/operations/edit/editModes";
+import { ProjectEditor, successfulEdit } from "../../../src/operations/edit/projectEditor";
 import { InMemoryProject } from "../../../src/project/mem/InMemoryProject";
 import { Project } from "../../../src/project/Project";
 

--- a/test/operations/edit/editAllTest.ts
+++ b/test/operations/edit/editAllTest.ts
@@ -1,0 +1,47 @@
+import "mocha";
+
+import * as assert from "power-assert";
+
+import { fromListRepoFinder, fromListRepoLoader } from "../../../src/operations/common/fromProjectList";
+import { editAll } from "../../../src/operations/edit/editAll";
+import { ProjectEditor, successfulEdit } from "../../../src/operations/edit/projectEditor";
+import { CustomExecutionEditInfo } from "../../../src/operations/edit/editModes";
+import { InMemoryProject } from "../../../src/project/mem/InMemoryProject";
+import { Project } from "../../../src/project/Project";
+
+describe("editAll", () => {
+
+    it("should edit none", done => {
+        const editor: ProjectEditor = p => {
+            p.addFileSync("thing", "1");
+            return Promise.resolve(successfulEdit(p, true));
+        };
+
+        const projects = [
+            new InMemoryProject(""),
+        ];
+
+        const projectsEdited: Project[] = [];
+
+        const cei: CustomExecutionEditInfo = {
+            commitMessage : "Thing",
+            edit: p => {
+                projectsEdited.push(p);
+                return Promise.resolve(successfulEdit(p));
+            },
+        };
+
+        editAll(null, null, editor, cei,
+            fromListRepoFinder(projects),
+            p => true,
+            fromListRepoLoader(projects))
+            .then(edits => {
+                assert(edits.length === projects.length);
+                assert(!edits.some(e => !e.edited));
+                assert.deepEqual(projectsEdited, projects);
+                done();
+            }).catch(done);
+
+    });
+
+});

--- a/test/operations/edit/editAllTest.ts
+++ b/test/operations/edit/editAllTest.ts
@@ -4,14 +4,14 @@ import * as assert from "power-assert";
 
 import { fromListRepoFinder, fromListRepoLoader } from "../../../src/operations/common/fromProjectList";
 import { editAll } from "../../../src/operations/edit/editAll";
-import { CustomExecutionEditInfo } from "../../../src/operations/edit/editModes";
+import { CustomExecutionEditMode } from "../../../src/operations/edit/editModes";
 import { ProjectEditor, successfulEdit } from "../../../src/operations/edit/projectEditor";
 import { InMemoryProject } from "../../../src/project/mem/InMemoryProject";
 import { Project } from "../../../src/project/Project";
 
 describe("editAll", () => {
 
-    it("should edit none", done => {
+    it("should edit repo", done => {
         const editor: ProjectEditor = p => {
             p.addFileSync("thing", "1");
             return Promise.resolve(successfulEdit(p, true));
@@ -23,8 +23,8 @@ describe("editAll", () => {
 
         const projectsEdited: Project[] = [];
 
-        const cei: CustomExecutionEditInfo = {
-            commitMessage : "Thing",
+        const cei: CustomExecutionEditMode = {
+            message : "Thing",
             edit: p => {
                 projectsEdited.push(p);
                 return Promise.resolve(successfulEdit(p));

--- a/test/project/git/GitProjectTest.ts
+++ b/test/project/git/GitProjectTest.ts
@@ -79,7 +79,7 @@ describe("GitProject", () => {
         p.addFileSync("Thing", "1");
         const gp: GitProject = GitCommandGitProject.fromProject(p, GitHubToken);
         gp.init().then(() => gp.commit("Added a Thing").then(c => {
-            exec.exec("git status; git log", { cwd: p.baseDir }, (err, stdout, stderr) => {
+            exec.exec("git status; git log", {cwd: p.baseDir}, (err, stdout, stderr) => {
                 if (err) {
                     // node couldn't execute the command
                     console.error(`Node err on dir [${p.baseDir}]: ${err}`);
@@ -181,11 +181,12 @@ describe("GitProject", () => {
 
         newRepo().then(_ => {
             return cloneEditAndPush(GitHubToken, TargetOwner, TargetRepo,
-                    p => p.addFileSync("Cat", "hat"),
-                "Commit message", "thing2", {
-                title: "Thing2",
-                body: "Adds another character now",
-            })
+                p => p.addFileSync("Cat", "hat"), {
+                    branch: "thing2",
+                    title: "Thing2",
+                    commitMessage: "Commit message",
+                    body: "Adds another character now",
+                })
                 .then(() => done());
         }).catch(done);
     }).timeout(20000);
@@ -200,7 +201,7 @@ describe("GitProject", () => {
 
                 gp.checkout(sha)
                     .then(_ => {
-                        exec.exec("git status", { cwd: baseDir }, (err, stdout, stderr) => {
+                        exec.exec("git status", {cwd: baseDir}, (err, stdout, stderr) => {
                             if (err) {
                                 // node couldn't execute the command
                                 console.error(`Node err on dir [${baseDir}]: ${err}`);

--- a/test/project/git/GitProjectTest.ts
+++ b/test/project/git/GitProjectTest.ts
@@ -184,7 +184,7 @@ describe("GitProject", () => {
                 p => p.addFileSync("Cat", "hat"), {
                     branch: "thing2",
                     title: "Thing2",
-                    commitMessage: "Commit message",
+                    message: "Commit message",
                     body: "Adds another character now",
                 })
                 .then(() => done());


### PR DESCRIPTION
Overhauls editors and reviewers using a more functional approach via functions such as `editAll` and `reviewAll`. The generic `doWithAllRepos` function can be used to run shell-scripts or perform any other cross-repo operation.

Also adds `EditInfo` so editors can pass in whether it uses a branch, PR etc. even down to individual project level.