### PR TITLE
Scanning for command and event handlers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ npm-debug.log
 /release
 graphql.config.json
 git-info.json
+/.vscode

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "@types/express": "^4.0.37",
     "@types/express-session": "^1.15.3",
     "@types/fs-extra": "^4.0.2",
+    "@types/glob": "^5.0.33",
     "@types/graphql": "^0.11.5",
     "@types/inquirer": "0.0.35",
     "@types/isomorphic-fetch": "0.0.34",

--- a/src/automationClient.ts
+++ b/src/automationClient.ts
@@ -185,7 +185,6 @@ export class AutomationClient {
     }
 }
 
-export function automationClient(configuration: Configuration):
-    AutomationClient {
+export function automationClient(configuration: Configuration): AutomationClient {
     return new AutomationClient(configuration);
 }

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -111,12 +111,17 @@ export function resolveModuleConfig(userConfig: UserConfig, pkgJson: any): Modul
 
 const AtomistConfigFile = "atomist.config.js";
 
-export function findConfiguration(): Configuration {
+export function findConfiguration(path?: string): Configuration {
     const moduleConfig = getModuleConfig();
 
     // TODO we could add an env variable ATOMIST_CONFIG for people to specify a path to a file to use
     const glob = require("glob");
-    const files = glob.sync(`**/${AtomistConfigFile}`, {ignore: "node_modules/**"});
+    const files = glob.sync(`**/${AtomistConfigFile}`, { ignore: "node_modules/**" });
+
+    // add the provided file
+    if (path) {
+        files.push(path);
+    }
 
     if (files.length === 0) {
         throw new Error(`No '${AtomistConfigFile}' file found in project`);

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -5,6 +5,7 @@ import {
     declareIngestor,
     declareMappedParameter,
     declareParameter,
+    declareParameters,
     declareSecret,
     declareTags,
 } from "./internal/metadata/decoratorSupport";
@@ -53,7 +54,7 @@ export function CommandHandler(description: string, intent?: string[] | string) 
  * @constructor
  */
 export function Parameters() {
-    return (obj: any) => { declareCommandHandler(obj, undefined, []); };
+    return (obj: any) => { declareParameters(obj); };
 }
 
 export function Ingestor(

--- a/src/internal/metadata/decoratorSupport.ts
+++ b/src/internal/metadata/decoratorSupport.ts
@@ -1,5 +1,8 @@
-
 import { ParameterType } from "../../metadata/automationMetadata";
+import {
+    registerCommand,
+    registerEvent,
+} from "../../scan";
 
 export interface BaseParameter {
     readonly pattern: RegExp;
@@ -151,6 +154,13 @@ export function declareCommandHandler(obj: any, description: string, intent?: st
     } else if (intent) {
         declareIntent(obj, [intent]);
     }
+    registerCommand(obj);
+    return obj;
+}
+
+export function declareParameters(obj: any) {
+    set_metadata(obj, "__name", obj.prototype.constructor.name);
+    set_metadata(obj, "__kind", "parameters");
     return obj;
 }
 
@@ -173,6 +183,7 @@ export function declareEventHandler(
     obj: any, description: string, subscription: string) {
     declareRug(obj, "event-handler", description);
     set_metadata(obj, "__subscription", subscription);
+    registerEvent(obj);
     return obj;
 }
 

--- a/src/internal/metadata/metadataReading.ts
+++ b/src/internal/metadata/metadataReading.ts
@@ -55,6 +55,16 @@ function metadataFromDecorator(r: any): CommandHandlerMetadata | EventHandlerMet
                 mapped_parameters: mappedParameterMetadataFromInstance(r),
                 secrets: secretsMetadataFromInstance(r),
             };
+        case "parameters" :
+            return {
+                name: r.__name,
+                description: r.__description,
+                tags: r.__tags ? r.__tags : [],
+                intent: r.__intent ? r.__intent : [],
+                parameters: parametersFromInstance(r),
+                mapped_parameters: mappedParameterMetadataFromInstance(r),
+                secrets: secretsMetadataFromInstance(r),
+            };
         case "event-handler" :
             // Validate subscription
             const errors = GraphQL.validateQuery(r.__subscription);

--- a/src/internal/transport/websocket/payloads.ts
+++ b/src/internal/transport/websocket/payloads.ts
@@ -26,7 +26,12 @@ function convertRegExpValuesToString(data: any): any {
 
 function prepareCommandRegistration(c: CommandHandlerMetadata) {
     return {
-        ...c,
+        name: c.name,
+        description: c.description,
+        tags: c.tags,
+        intent: c.intent,
+        parameters: c.parameters,
+        mapped_parameters: c.mapped_parameters,
         secrets: c.secrets ? c.secrets.map(s => s.path) : [],
     };
 }

--- a/src/scan.ts
+++ b/src/scan.ts
@@ -1,0 +1,115 @@
+import * as appRoot from "app-root-path";
+import { Configuration } from "./configuration";
+import {
+    HandleCommand,
+    HandleEvent,
+} from "./Handlers";
+import { logger } from "./internal/util/logger";
+import { toStringArray } from "./internal/util/string";
+import { Maker } from "./util/constructionUtils";
+
+class HandlerRegistry {
+
+    public commands: Array<Maker<HandleCommand>> = [];
+    public events: Array<Maker<HandleEvent<any>>> = [];
+    private scanForCommands: boolean = false;
+    private scanForEvents: boolean = false;
+
+    public registerCommand(command: any) {
+        if (this.scanForCommands) {
+            logger.debug(`Registered command '${command.name}'`);
+            if (typeof command === "function") {
+                this.commands.push(command);
+            } else {
+                this.commands.push(() => Object.create(command));
+            }
+        }
+    }
+
+    public registerEvent(event: any) {
+        if (this.scanForEvents) {
+            logger.debug(`Registered event '${event.name}'`);
+            if (typeof event === "function") {
+                this.events.push(event);
+            } else {
+                this.events.push(() => Object.create(event));
+            }
+        }
+    }
+
+    public start(commands: boolean, events: boolean) {
+        this.commands = [];
+        this.scanForCommands = commands;
+
+        this.events = [];
+        this.scanForEvents = events;
+    }
+}
+
+const registry = new HandlerRegistry();
+
+export function registerCommand(command: any) {
+    registry.registerCommand(command);
+}
+
+export function registerEvent(event: any) {
+    registry.registerEvent(event);
+}
+
+/*
+ * Scan the node module/project for command handlers.
+ * Optional glob patterns can be specified to narrow the search.
+ */
+export function scanCommands(patterns: string | string[] =
+                                 [ "**/handlers/commands/**/*.js" ]): Array<Maker<HandleCommand>> {
+    registry.start(true, false);
+    // tslint:disable-next-line:variable-name
+    const _patterns = toStringArray(patterns);
+    logger.info(`Scanning for commands using file patterns: ${_patterns.join(", ")}`);
+    scan(_patterns);
+    return registry.commands;
+}
+
+/*
+ * Scan the node module/project for event handlers.
+ * Optional glob patterns can be specified to narrow the search.
+ */
+export function scanEvents(patterns: string | string[] =
+                               [ "**/handlers/events/**/*.js" ]): Array<Maker<HandleEvent<any>>> {
+    registry.start(false, true);
+    // tslint:disable-next-line:variable-name
+    const _patterns = toStringArray(patterns);
+    logger.info(`Scanning for events using file patterns: ${_patterns.join(", ")}`);
+    scan(_patterns);
+    return registry.events;
+}
+
+/*
+ * Enable scanning on the given Configuration instance.
+ */
+export function enableDefaultScanning(configuration: Configuration): Configuration {
+    if (configuration.commands === undefined) {
+        configuration.commands = scanCommands();
+    }
+    if (configuration.events === undefined) {
+        configuration.events = scanEvents();
+    }
+    return configuration;
+}
+
+function scan(patterns: string[]) {
+    const glob = require("glob");
+    patterns.forEach(pattern => {
+        const files = glob.sync(pattern, {ignore: "node_modules/**"});
+        files.forEach(f => safeRequire(f));
+    });
+}
+
+function safeRequire(file: string) {
+    try {
+        logger.debug(`Scanning file '${file}'`);
+        require(`${appRoot.path}/${file}`);
+    } catch (err) {
+        logger.warn(`Can't require '${file}': ${err.message}`);
+    }
+}

--- a/src/start.client.ts
+++ b/src/start.client.ts
@@ -5,23 +5,24 @@ import * as yargs from "yargs";
 
 import { automationClient } from "./automationClient";
 import { findConfiguration } from "./configuration";
+import { enableDefaultScanning } from "./scan";
 
-const config = findConfiguration();
-const node = automationClient(config);
+const configuration = enableDefaultScanning(findConfiguration());
+const node = automationClient(configuration);
 
-if (config.commands) {
-    config.commands.forEach(c => {
+if (configuration.commands) {
+    configuration.commands.forEach(c => {
         node.withCommandHandler(c);
     });
 }
-if (config.events) {
-    config.events.forEach(e => {
+if (configuration.events) {
+    configuration.events.forEach(e => {
         node.withEventHandler(e);
     });
 }
 
-if (config.ingestors) {
-    config.ingestors.forEach(e => {
+if (configuration.ingestors) {
+    configuration.ingestors.forEach(e => {
         node.withIngestor(e);
     });
 }

--- a/test/atomist.config.ts
+++ b/test/atomist.config.ts
@@ -1,15 +1,11 @@
 import { Configuration } from "../src/configuration";
 import { RequestProcessor } from "../src/internal/transport/RequestProcessor";
 import { guid } from "../src/internal/util/string";
-import { SpringBootSeed } from "../src/operations/generate/java/SpringBootSeed";
+import { scanCommands, scanEvents } from "../src/scan";
 import { AutomationEventListenerSupport } from "../src/server/AutomationEventListener";
 import { HelloWorld } from "./command/HelloWorld";
-import { PlainHelloWorld } from "./command/PlainHelloWorld";
-import { SendStartupMessage } from "./command/SendStartupMessage";
-import { HelloIngestor } from "./event/HelloIngestor";
-import { HelloIssue } from "./event/HelloIssue";
 
-export const GitHubToken = process.env.GITHUB_TOKEN;
+export const GitHubToken = process.env.GITHUB_TOKEN || "<please set GITHUB_TOKEN env variable>";
 
 // const host = "https://automation.atomist.com";
 const host = "https://automation-staging.atomist.services";
@@ -47,22 +43,14 @@ export const configuration: Configuration = {
     name: "@atomist/automation-node-tests",
     version: "0.0.6",
     teamIds: ["T1L0VDKJP"],
+    token: GitHubToken,
     commands: [
+        ...scanCommands( ["**/metadata/addAtomistSpringAgent.js", "**/command/Search*.js"] ),
         HelloWorld,
-        SendStartupMessage,
-        () => new PlainHelloWorld(),
-        // () => new UniversalSeed(),
-        // () => new JavaSeed(),
-        () => new SpringBootSeed(),
     ],
     events: [
-        HelloIssue,
-        // () => new AlwaysOkEventHandler(),
+        ...scanEvents("**/event/*.js"),
     ],
-    ingestors: [
-        HelloIngestor,
-    ],
-    token: GitHubToken,
     http: {
         enabled: true,
         forceSecure: false,
@@ -74,9 +62,10 @@ export const configuration: Configuration = {
             },
             bearer: {
                 enabled: false,
+                token: GitHubToken,
             },
             github: {
-                enabled: true,
+                enabled: false,
                 clientId: "092b3124ced86d5d1569",
                 clientSecret: "71d72f657d4402009bd8d728fc1967939c343793",
                 callbackUrl: "http://localhost:2866",
@@ -93,6 +82,6 @@ export const configuration: Configuration = {
         api: `${host}/registration`,
     },
     applicationEvents: {
-        enabled: true,
+        enabled: false,
     },
 };

--- a/test/internal/metadata/addAtomistSpringAgent.ts
+++ b/test/internal/metadata/addAtomistSpringAgent.ts
@@ -30,4 +30,7 @@ export const addAtomistSpringAgent: HandleCommand =
             ctx.messageClient.respond("I got your message: slackTeam=" + params.slackTeam)
                 .then(succeed),
         AddAtomistSpringAgentParams,
-        "AddAtomistSpringAgent");
+        "AddAtomistSpringAgent",
+        "add the Atomist Agent to a Spring Boot project",
+        "add agent",
+        [ "atomist", "spring", "agent" ]);

--- a/test/scanTest.ts
+++ b/test/scanTest.ts
@@ -1,0 +1,14 @@
+import "mocha";
+import * as assert from "power-assert";
+
+import { findConfiguration } from "../src/configuration";
+
+describe("scan", () => {
+
+    // This test only works when run from the IDE; with mocha the JS files are not visible
+    it.skip("should find test handlers", () => {
+        const configuration = findConfiguration();
+        assert(configuration.commands.length === 3);
+        assert(configuration.events.length === 1);
+    });
+});


### PR DESCRIPTION
This takes away the need to explicitly register handlers. It can be mixed with explicit registeration and can be configured with glob patterns. 

Also fixes issues with functional-style command handlers and metadata. 