### PR TITLE
Merge parameters from an instance

### DIFF
--- a/src/spi/message/MessageClient.ts
+++ b/src/spi/message/MessageClient.ts
@@ -93,8 +93,9 @@ export interface CommandReference {
     parameterName?: string;
 }
 
-export function buttonForCommand(buttonSpec: ButtonSpec, command: any, parameters: {} = {}): Action {
+export function buttonForCommand(buttonSpec: ButtonSpec, command: any, parameters: any = {}): Action {
     const cmd = commandName(command);
+    parameters = mergeParameters(command, parameters);
     const id = cmd.toLocaleLowerCase();
     const action = rugButtonFrom(buttonSpec, { id }) as CommandReferencingAction;
     action.command = {
@@ -106,8 +107,9 @@ export function buttonForCommand(buttonSpec: ButtonSpec, command: any, parameter
 }
 
 export function menuForCommand(selectSpec: SelectSpec, command: any, parameterName: string,
-                               parameters?: {}): Action {
+                               parameters: any = {}): Action {
     const cmd = commandName(command);
+    parameters = mergeParameters(command, parameters);
     const id = cmd.toLocaleLowerCase();
     const action = rugMenuFrom(selectSpec, { id, parameterName }) as CommandReferencingAction;
     action.command = {
@@ -133,6 +135,16 @@ export function commandName(command: any): string {
     }
 }
 
+export function mergeParameters(command: any, parameters: any): any {
+    // Resue parameters defined on the instance
+    if (typeof command !== "string" && typeof command !== "function") {
+        parameters = {
+            ...command,
+            ...parameters,
+        };
+    }
+    return parameters;
+}
 function rugButtonFrom(action: ButtonSpec, command: any): Action {
     if (!command.id) {
         throw new Error(`Please provide a valid non-empty command id`);

--- a/test/spi/message/MessageClientTest.ts
+++ b/test/spi/message/MessageClientTest.ts
@@ -1,30 +1,61 @@
 import "mocha";
-
 import * as assert from "power-assert";
-import { commandName } from "../../../src/spi/message/MessageClient";
+import {
+    commandName,
+    mergeParameters,
+} from "../../../src/spi/message/MessageClient";
 import { HelloWorld } from "../../command/HelloWorld";
 import { PlainHelloWorld } from "../../command/PlainHelloWorld";
 
 describe("MessageClient", () => {
 
-    it("extract commandName from string", () => {
-        assert(commandName("HelloWorld") === "HelloWorld");
+    describe("commandName", () => {
+
+        it("extract commandName from string", () => {
+            assert(commandName("HelloWorld") === "HelloWorld");
+        });
+
+        it("extract commandName from command handler instance", () => {
+            assert(commandName(new HelloWorld()) === "HelloWorld");
+        });
+
+        it("extract commandName from plain command handler instance", () => {
+            assert(commandName(new PlainHelloWorld()) === "PlainHelloWorld");
+        });
+
+        it("extract commandName from command handler constructor", () => {
+            assert(commandName(HelloWorld) === "HelloWorld");
+        });
+
+        it("extract commandName from plain command handler constructor", () => {
+            assert(commandName(PlainHelloWorld) === "PlainHelloWorld");
+        });
     });
 
-    it("extract commandName from command handler instance", () => {
-        assert(commandName(new HelloWorld()) === "HelloWorld");
-    });
+    describe("mergeParameters", () => {
 
-    it("extract commandName from plain command handler instance", () => {
-        assert(commandName(new PlainHelloWorld()) === "PlainHelloWorld");
-    });
+        it("don't extract parameters from string", () => {
+            assert.deepEqual(mergeParameters("HelloWorld", {}), {});
+        });
 
-    it("extract commandName from command handler constructor", () => {
-        assert(commandName(HelloWorld) === "HelloWorld");
-    });
+        it("don't extract parameters from constuctor", () => {
+            assert.deepEqual(mergeParameters(HelloWorld, {}), {});
+        });
 
-    it("extract commandName from plain command handler constructor", () => {
-        assert(commandName(PlainHelloWorld) === "PlainHelloWorld");
+        it("extract parameters from instance", () => {
+            const handler = new HelloWorld();
+            handler.name = "cd";
+            handler.userToken = "token_bla";
+            assert.deepEqual(mergeParameters(handler, {}), { name: "cd", userToken: "token_bla" });
+        });
+
+        it("overwrite parameters from instance with explicit parameters", () => {
+            const handler = new HelloWorld();
+            handler.name = "cd";
+            handler.userToken = "token_bla";
+            assert.deepEqual(mergeParameters(handler, { name: "dd" }),
+                { name: "dd", userToken: "token_bla" });
+        });
     });
 
 });


### PR DESCRIPTION
This takes away the need to create a parameters map via strings. 

Now you can just do:

```
const handler = new HellloWorld();
handler.some_param = "bla";

buttonForCommand({ text: "hello" }, handler);
```

[atomist:enable-auto-merge]