### PR TITLE
Don't catch errors in the editor and blame it on the load

### DIFF
--- a/src/operations/common/repoUtils.ts
+++ b/src/operations/common/repoUtils.ts
@@ -34,13 +34,16 @@ export function doWithAllRepos<R, P>(ctx: HandlerContext,
             Promise.all(
                 ids.map(id =>
                     repoLoader(id)
-                        .then(p => action(p, parameters))
                         .catch(err => {
                             logger.warn("Unable to load repo %s:%s: %s", id.owner, id.repo, err);
                             return undefined;
-                        }),
-                ),
-            ).then(proms => proms.filter(prom => prom)),
+                        })
+                        .then(p => {
+                            if (p) {
+                                return action(p, parameters);
+                            }
+                        })))
+                .then(proms => proms.filter(prom => prom)),
         );
 }
 

--- a/src/project/local/NodeFsLocalProject.ts
+++ b/src/project/local/NodeFsLocalProject.ts
@@ -6,7 +6,6 @@ import * as fpath from "path";
 
 import * as gs from "glob-stream";
 import * as stream from "stream";
-import { promisify } from "util";
 import { deleteFolderRecursive } from "../../internal/util/file";
 import { logger } from "../../internal/util/logger";
 import { RepoRef, SimpleRepoId } from "../../operations/common/RepoId";


### PR DESCRIPTION
My editor failed somewhere and the message was "Unable to load repo" which is inaccurate.

Let failures in my editor percolate up.