### PR TITLE
Add TypeScript/JavaScript parsing & path expression support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,9 +19,9 @@
       }
     },
     "@atomist/tree-path": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@atomist/tree-path/-/tree-path-0.1.2.tgz",
-      "integrity": "sha512-TKODOXlKyHnQrxTlBvovhcBB9R5J072rH/nPdNqXTrDqlvJDYosWe+tZAvbQ7eUuo2Hf6+EPRYrlybxUNGxIYA==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@atomist/tree-path/-/tree-path-0.1.3.tgz",
+      "integrity": "sha512-Tf+UPDeEoEIgyP36Ob55CKyjEtivWepp9mU0CFgQtd+gu5hg580kOwrg91V6S1eYKgQZ8dtBdp62heU3kGhoOQ==",
       "requires": {
         "@atomist/microgrammar": "0.7.0"
       }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@atomist/microgrammar": "^0.7.0",
     "@atomist/slack-messages": "^0.12.0",
-    "@atomist/tree-path": "^0.1.2",
+    "@atomist/tree-path": "^0.1.3",
     "@typed/curry": "^1.0.1",
     "@types/helmet": "0.0.37",
     "@types/ws": "^3.0.2",

--- a/src/tree/ast/typescript/TypeScriptFileParser.ts
+++ b/src/tree/ast/typescript/TypeScriptFileParser.ts
@@ -58,6 +58,9 @@ class TypeScriptAstNodeTreeNode implements TreeNode {
         if (this.$children.length === 0) {
             // Get it off the JSON if it doesn't matter
             this.$children = undefined;
+        } else {
+            // It's a non-terminal, so the name needs to be the kind
+            this.$name = ts.SyntaxKind[node.kind];
         }
         this.$value = extractValue(sourceFile, node);
     }

--- a/src/tree/ast/typescript/TypeScriptFileParser.ts
+++ b/src/tree/ast/typescript/TypeScriptFileParser.ts
@@ -12,7 +12,7 @@ import * as ts from "typescript";
  */
 export class TypeScriptFileParser implements FileParser {
 
-    public rootName = "ts";
+    public rootName = ts.SyntaxKind[ts.SyntaxKind.SourceFile];
 
     constructor(public scriptTarget: ts.ScriptTarget = ts.ScriptTarget.ES2016,
                 public scriptKind: ts.ScriptKind = ts.ScriptKind.TS) {
@@ -45,6 +45,7 @@ class TypeScriptAstNodeTreeNode implements TreeNode {
 
     constructor(node: ts.Node) {
         //console.log(JSON.stringify(node, null, 2));
+        this.$name = extractName(node);
 
         function visit(children: TreeNode[], n: ts.Node) {
             if (!!n) {
@@ -52,22 +53,13 @@ class TypeScriptAstNodeTreeNode implements TreeNode {
             }
         }
 
-        this.$name = extractName(node);
         ts.forEachChild(node, curry(visit)(this.$children));
         if (this.$children.length === 0) {
             // Get it off the JSON if it doesn't matter
             this.$children = undefined;
         }
 
-        // this.$offset = m.$offset;
-        // if (isTreePatternMatch(m)) {
-        //     const subs = m.submatches();
-        //     this.$children = Object.getOwnPropertyNames(subs)
-        //         .map(prop => {
-        //             const sub = subs[prop];
-        //             // console.log("Exposing child %s.%s as [%s]", $name, prop, JSON.stringify(sub));
-        //             return new TypeScriptAstNodeTreeNode(prop, sub);
-        //         });
+        // TODO set offsets
 
         // console.log("Exposing terminal %s as [%s]: value=[%s]", $name, JSON.stringify(m), m.$matched);
         //this.$value = node.getText();
@@ -77,6 +69,7 @@ class TypeScriptAstNodeTreeNode implements TreeNode {
 
 function extractName(node: ts.Node): string {
     if ((node as any).name) {
+        // TODO this looks fragile
         return (node as any).name.escapedText;
     } else {
         return ts.SyntaxKind[node.kind];

--- a/src/tree/ast/typescript/TypeScriptFileParser.ts
+++ b/src/tree/ast/typescript/TypeScriptFileParser.ts
@@ -3,11 +3,12 @@ import { FileParser } from "../FileParser";
 
 import { File } from "../../../project/File";
 
+import { defineDynamicProperties } from "@atomist/tree-path/manipulation/enrichment";
 import { curry } from "@typed/curry";
 import * as ts from "typescript";
 
 /**
- * Allow path expressions against results from a single microgrammar
+ * Allow path expressions against ASTs from the TypeScript parser
  */
 export class TypeScriptFileParser implements FileParser {
 
@@ -22,15 +23,14 @@ export class TypeScriptFileParser implements FileParser {
             .then(content => {
                 const sourceFile = ts.createSourceFile(f.name, content, this.scriptTarget, false, this.scriptKind);
                 const root = new TypeScriptAstNodeTreeNode(sourceFile, sourceFile);
-                //defineDynamicProperties(root);
-                //fillInEmptyNonTerminalValues(root, content);
+                defineDynamicProperties(root);
                 return root;
             });
     }
 }
 
 /**
- * TreeNode implementation backed by a microgrammar match
+ * TreeNode implementation backed by a node from the TypeScript parser
  */
 class TypeScriptAstNodeTreeNode implements TreeNode {
 
@@ -43,7 +43,6 @@ class TypeScriptAstNodeTreeNode implements TreeNode {
     public readonly $offset: number;
 
     constructor(sourceFile: ts.SourceFile, node: ts.Node) {
-        //console.log(JSON.stringify(node, null, 2));
         this.$name = extractName(node);
         this.$offset = node.getStart(sourceFile, true);
 

--- a/src/tree/ast/typescript/TypeScriptFileParser.ts
+++ b/src/tree/ast/typescript/TypeScriptFileParser.ts
@@ -4,8 +4,8 @@ import { FileParser } from "../FileParser";
 import { defineDynamicProperties, fillInEmptyNonTerminalValues } from "@atomist/tree-path/manipulation/enrichment";
 import { File } from "../../../project/File";
 
-import * as ts from "typescript";
 import { curry } from "@typed/curry";
+import * as ts from "typescript";
 
 /**
  * Allow path expressions against results from a single microgrammar

--- a/src/tree/ast/typescript/TypeScriptFileParser.ts
+++ b/src/tree/ast/typescript/TypeScriptFileParser.ts
@@ -1,0 +1,84 @@
+import { TreeNode } from "@atomist/tree-path/TreeNode";
+import { FileParser } from "../FileParser";
+
+import { defineDynamicProperties, fillInEmptyNonTerminalValues } from "@atomist/tree-path/manipulation/enrichment";
+import { File } from "../../../project/File";
+
+import * as ts from "typescript";
+import { curry } from "@typed/curry";
+
+/**
+ * Allow path expressions against results from a single microgrammar
+ */
+export class TypeScriptFileParser implements FileParser {
+
+    public rootName = "ts";
+
+    constructor(public scriptTarget: ts.ScriptTarget = ts.ScriptTarget.ES2016,
+                public scriptKind: ts.ScriptKind = ts.ScriptKind.TS) {
+    }
+
+    public toAst(f: File): Promise<TreeNode> {
+        return f.getContent()
+            .then(content => {
+                const node = ts.createSourceFile(f.name, content, this.scriptTarget, false, this.scriptKind);
+                const root = new TypeScriptAstNodeTreeNode(node);
+                defineDynamicProperties(root);
+                fillInEmptyNonTerminalValues(root, content);
+                return root;
+            });
+    }
+}
+
+/**
+ * TreeNode implementation backed by a microgrammar match
+ */
+class TypeScriptAstNodeTreeNode implements TreeNode {
+
+    public readonly $children: TreeNode[] = [];
+
+    public readonly $name;
+
+    public $value: string;
+
+    public readonly $offset: number;
+
+    constructor(node: ts.Node) {
+        //console.log(JSON.stringify(node, null, 2));
+
+        function visit(children: TreeNode[], n: ts.Node) {
+            if (!!n) {
+                children.push(new TypeScriptAstNodeTreeNode(n));
+            }
+        }
+
+        this.$name = extractName(node);
+        ts.forEachChild(node, curry(visit)(this.$children));
+        if (this.$children.length === 0) {
+            // Get it off the JSON if it doesn't matter
+            this.$children = undefined;
+        }
+
+        // this.$offset = m.$offset;
+        // if (isTreePatternMatch(m)) {
+        //     const subs = m.submatches();
+        //     this.$children = Object.getOwnPropertyNames(subs)
+        //         .map(prop => {
+        //             const sub = subs[prop];
+        //             // console.log("Exposing child %s.%s as [%s]", $name, prop, JSON.stringify(sub));
+        //             return new TypeScriptAstNodeTreeNode(prop, sub);
+        //         });
+
+        // console.log("Exposing terminal %s as [%s]: value=[%s]", $name, JSON.stringify(m), m.$matched);
+        //this.$value = node.getText();
+    }
+
+}
+
+function extractName(node: ts.Node): string {
+    if ((node as any).name) {
+        return (node as any).name.escapedText;
+    } else {
+        return ts.SyntaxKind[node.kind];
+    }
+}

--- a/test/tree/ast/typescript/TypeScriptFileParserTest.ts
+++ b/test/tree/ast/typescript/TypeScriptFileParserTest.ts
@@ -1,0 +1,128 @@
+import "mocha";
+import * as assert from "power-assert";
+import { InMemoryFile } from "../../../../src/project/mem/InMemoryFile";
+import { TypeScriptFileParser } from "../../../../src/tree/ast/typescript/TypeScriptFileParser";
+
+describe("TypeScriptFileParser", () => {
+
+    it("should parse a file", done => {
+        const f = new InMemoryFile("script.ts", "const x = 1;");
+        new TypeScriptFileParser()
+            .toAst(f)
+            .then(root => {
+                console.log(JSON.stringify(root, null, 2));
+                // assert(root.$name === "people");
+                // assert(root.$children.length === 2);
+                // const tom = root.$children[0] as TreeNode;
+                // // console.log(JSON.stringify(tom));
+                // assert(tom.$name === "person");
+                // assert(tom.$children.length === 2);
+                done();
+            }).catch(done);
+    });
+
+    // it("should parse a file and allow scalar navigation via property", done => {
+    //     const f = new InMemoryFile("Thing", "Tom:16 Mary:25");
+    //     const mg = Microgrammar.fromString<Person>("${name}:${age}", {
+    //         age: Integer,
+    //     });
+    //     new MicrogrammarBasedFileParser("people", "person", mg)
+    //         .toAst(f)
+    //         .then(root => {
+    //             // console.log(JSON.stringify(root, null, 2));
+    //             assert(root.$name === "people");
+    //             assert(root.$children.length === 2);
+    //             const tom = root.$children[0] as Person & TreeNode;
+    //             assert(tom.$name === "person");
+    //             assert(tom.name === "Tom", "Name=" + tom.name);
+    //             done();
+    //         }).catch(done);
+    // });
+    //
+    // it("should parse a file and allow array navigation via property", done => {
+    //     const f = new InMemoryFile("Thing", "Tom:16 Mary:25");
+    //     const mg = Microgrammar.fromString<Person>("${name}:${age}", {
+    //         age: Integer,
+    //     });
+    //     new MicrogrammarBasedFileParser("people", "person", mg)
+    //         .toAst(f)
+    //         .then(root => {
+    //             console.log(JSON.stringify(root, null, 2));
+    //             assert(root.$name === "people");
+    //             // Check the array property
+    //             const tom = (root as any).persons[0] as Person & TreeNode;
+    //             assert(tom.$name === "person");
+    //             assert(tom.name === "Tom", "Name=" + tom.name);
+    //             const mary = (root as any).persons[1] as Person & TreeNode;
+    //             assert(mary.$name === "person");
+    //             assert(mary.name === "Mary", "Name=" + mary.name);
+    //             done();
+    //         }).catch(done);
+    // });
+    //
+    // interface KidFact {
+    //     birthYear: number;
+    //     food: string;
+    // }
+    //
+    // interface Kid {
+    //     name: string;
+    //     fact: KidFact;
+    // }
+    //
+    // it("should parse a file and allow array navigation via property with a nested grammar", done => {
+    //     const f = new InMemoryFile("Family", "Linda:[2007, mushrooms] Evelyn:[2005, sugar]");
+    //     const mg = Microgrammar.fromString<Kid>("${name}:${fact}", {
+    //         fact: Microgrammar.fromString<KidFact>("[${birthYear},${food}]", {
+    //             birthYear: Integer,
+    //         }),
+    //     });
+    //     new MicrogrammarBasedFileParser("family", "kid", mg)
+    //         .toAst(f)
+    //         .then(root => {
+    //             console.log(JSON.stringify(root, null, 2));
+    //             // Check the array property
+    //             const linda = (root as any).kids[0] as Kid & TreeNode;
+    //             assert(linda.name === "Linda", "Name=" + linda.name);
+    //             const evelyn = (root as any).kids[1] as Kid & TreeNode;
+    //             assert(evelyn.name === "Evelyn", "Name=" + evelyn.name);
+    //             // this Integer-matcher should be converting it to a number automatically. microgrammar#34
+    //             assert(+evelyn.fact.birthYear === 2005, "birth year " + evelyn.fact.birthYear );
+    //             assert(evelyn.fact.food === "sugar");
+    //             done();
+    //         }).catch(done);
+    // });
+    //
+    // it("should parse a file and keep positions", done => {
+    //     const f = new InMemoryFile("Thing", "Tom:16 Mary:25");
+    //     const mg = Microgrammar.fromString<Person>("${name}:${age}", {
+    //         age: Integer,
+    //     });
+    //     new MicrogrammarBasedFileParser("people", "person", mg)
+    //         .toAst(f)
+    //         .then(root => {
+    //             assert(root.$name === "people");
+    //             let minOffset = -1;
+    //             let terminalCount = 0;
+    //             const v: TreeVisitor = tn => {
+    //                 console.log(tn.$name + "=" + tn.$value + ",offset=" + tn.$offset);
+    //                 if (tn.$name !== "people") {
+    //                     assert(tn.$offset !== undefined, `No offset on node with name ${tn.$name}`);
+    //                     assert(tn.$offset >= minOffset, `Must have position for ${JSON.stringify(tn)}`);
+    //                     if (!!tn.$value) {
+    //                         ++terminalCount;
+    //                         // It's a terminal
+    //                         assert(f.getContentSync().substr(tn.$offset, tn.$value.length) === tn.$value,
+    //                             `Unable to validate content for ${JSON.stringify(tn)}`);
+    //                     }
+    //                     minOffset = tn.$offset;
+    //                 }
+    //                 return true;
+    //             };
+    //             visit(root, v);
+    //             assert(terminalCount > 0);
+    //             done();
+    //         }).catch(done);
+    // });
+
+});

--- a/test/tree/ast/typescript/TypeScriptFileParserTest.ts
+++ b/test/tree/ast/typescript/TypeScriptFileParserTest.ts
@@ -1,3 +1,4 @@
+import { evaluateScalar } from "@atomist/tree-path/path/expressionEngine";
 import "mocha";
 import * as assert from "power-assert";
 import { InMemoryFile } from "../../../../src/project/mem/InMemoryFile";
@@ -11,65 +12,24 @@ describe("TypeScriptFileParser", () => {
             .toAst(f)
             .then(root => {
                 console.log(JSON.stringify(root, null, 2));
-                // assert(root.$name === "people");
-                // assert(root.$children.length === 2);
-                // const tom = root.$children[0] as TreeNode;
-                // // console.log(JSON.stringify(tom));
-                // assert(tom.$name === "person");
-                // assert(tom.$children.length === 2);
+                assert(root.$name === "SourceFile");
                 done();
             }).catch(done);
     });
 
-    // it("should parse a file and allow scalar navigation via property", done => {
-    //     const f = new InMemoryFile("Thing", "Tom:16 Mary:25");
-    //     const mg = Microgrammar.fromString<Person>("${name}:${age}", {
-    //         age: Integer,
-    //     });
-    //     new MicrogrammarBasedFileParser("people", "person", mg)
-    //         .toAst(f)
-    //         .then(root => {
-    //             // console.log(JSON.stringify(root, null, 2));
-    //             assert(root.$name === "people");
-    //             assert(root.$children.length === 2);
-    //             const tom = root.$children[0] as Person & TreeNode;
-    //             assert(tom.$name === "person");
-    //             assert(tom.name === "Tom", "Name=" + tom.name);
-    //             done();
-    //         }).catch(done);
-    // });
-    //
-    // it("should parse a file and allow array navigation via property", done => {
-    //     const f = new InMemoryFile("Thing", "Tom:16 Mary:25");
-    //     const mg = Microgrammar.fromString<Person>("${name}:${age}", {
-    //         age: Integer,
-    //     });
-    //     new MicrogrammarBasedFileParser("people", "person", mg)
-    //         .toAst(f)
-    //         .then(root => {
-    //             console.log(JSON.stringify(root, null, 2));
-    //             assert(root.$name === "people");
-    //             // Check the array property
-    //             const tom = (root as any).persons[0] as Person & TreeNode;
-    //             assert(tom.$name === "person");
-    //             assert(tom.name === "Tom", "Name=" + tom.name);
-    //             const mary = (root as any).persons[1] as Person & TreeNode;
-    //             assert(mary.$name === "person");
-    //             assert(mary.name === "Mary", "Name=" + mary.name);
-    //             done();
-    //         }).catch(done);
-    // });
-    //
-    // interface KidFact {
-    //     birthYear: number;
-    //     food: string;
-    // }
-    //
-    // interface Kid {
-    //     name: string;
-    //     fact: KidFact;
-    // }
-    //
+    it("should parse a file and use a path expression", done => {
+        const f = new InMemoryFile("script.ts", "const x = 1;");
+        new TypeScriptFileParser()
+            .toAst(f)
+            .then(root => {
+               // console.log(JSON.stringify(root, null, 2));
+                const value = evaluateScalar(root, "//VariableDeclarationList");
+                assert(!!value);
+                console.log(JSON.stringify(value));
+                done();
+            }).catch(done);
+    });
+
     // it("should parse a file and allow array navigation via property with a nested grammar", done => {
     //     const f = new InMemoryFile("Family", "Linda:[2007, mushrooms] Evelyn:[2005, sugar]");
     //     const mg = Microgrammar.fromString<Kid>("${name}:${fact}", {

--- a/test/tree/ast/typescript/TypeScriptFileParserTest.ts
+++ b/test/tree/ast/typescript/TypeScriptFileParserTest.ts
@@ -1,10 +1,12 @@
-import { evaluateScalar } from "@atomist/tree-path/path/expressionEngine";
+import { evaluateExpression, evaluateScalar, evaluateScalarValue } from "@atomist/tree-path/path/expressionEngine";
 import "mocha";
 import * as assert from "power-assert";
 import { InMemoryFile } from "../../../../src/project/mem/InMemoryFile";
 import { TypeScriptFileParser } from "../../../../src/tree/ast/typescript/TypeScriptFileParser";
 
 describe("TypeScriptFileParser", () => {
+
+    it("should handle ill-formed file");
 
     it("should parse a file", done => {
         const f = new InMemoryFile("script.ts", "const x = 1;");
@@ -17,7 +19,7 @@ describe("TypeScriptFileParser", () => {
             }).catch(done);
     });
 
-    it("should parse a file and use a path expression", done => {
+    it("should parse a file and use a path expression to find a node", done => {
         const f = new InMemoryFile("script.ts", "const x = 1;");
         new TypeScriptFileParser()
             .toAst(f)
@@ -26,6 +28,30 @@ describe("TypeScriptFileParser", () => {
                 const value = evaluateScalar(root, "//VariableDeclarationList");
                 assert(!!value);
                 console.log(JSON.stringify(value));
+                done();
+            }).catch(done);
+    });
+
+    it("should parse a file and use a path expression to find a value", done => {
+        const f = new InMemoryFile("script.ts", "const x = 1;");
+        new TypeScriptFileParser()
+            .toAst(f)
+            .then(root => {
+                // console.log(JSON.stringify(root, null, 2));
+                const value = evaluateScalarValue(root, "//VariableDeclaration/Identifier");
+                assert(value === "x");
+                done();
+            }).catch(done);
+    });
+
+    it("should parse a file and use a path expression to find values", done => {
+        const f = new InMemoryFile("script.ts", "const x = 1; let y = 2;");
+        new TypeScriptFileParser()
+            .toAst(f)
+            .then(root => {
+                // console.log(JSON.stringify(root, null, 2));
+                const value = evaluateExpression(root, "//VariableDeclaration/Identifier");
+                assert(value === "x");
                 done();
             }).catch(done);
     });

--- a/test/tree/ast/typescript/TypeScriptFileParserTest.ts
+++ b/test/tree/ast/typescript/TypeScriptFileParserTest.ts
@@ -1,9 +1,14 @@
-import { evaluateExpression, evaluateScalar, evaluateScalarValue } from "@atomist/tree-path/path/expressionEngine";
+import {
+    evaluateScalar, evaluateScalarValue,
+    evaluateScalarValues,
+} from "@atomist/tree-path/path/expressionEngine";
+import { TreeVisitor, visit } from "@atomist/tree-path/visitor";
 import "mocha";
 import * as assert from "power-assert";
 import { InMemoryFile } from "../../../../src/project/mem/InMemoryFile";
+import { InMemoryProject } from "../../../../src/project/mem/InMemoryProject";
+import { findMatches } from "../../../../src/tree/ast/astUtils";
 import { TypeScriptFileParser } from "../../../../src/tree/ast/typescript/TypeScriptFileParser";
-import { TreeNode } from "@atomist/tree-path/TreeNode";
 
 describe("TypeScriptFileParser", () => {
 
@@ -25,7 +30,7 @@ describe("TypeScriptFileParser", () => {
         new TypeScriptFileParser()
             .toAst(f)
             .then(root => {
-               // console.log(JSON.stringify(root, null, 2));
+                // console.log(JSON.stringify(root, null, 2));
                 const value = evaluateScalar(root, "//VariableDeclarationList");
                 assert(!!value);
                 console.log(JSON.stringify(value));
@@ -50,66 +55,70 @@ describe("TypeScriptFileParser", () => {
         new TypeScriptFileParser()
             .toAst(f)
             .then(root => {
-                const values = (evaluateExpression(root, "//Identifier") as TreeNode[])
-                    .map(n => n.$value);
-                assert.deepEqual(values, [ "x", "y"]);
+                const values = evaluateScalarValues(root, "//Identifier");
+                assert.deepEqual(values, ["x", "y"]);
                 done();
             }).catch(done);
     });
 
-    // it("should parse a file and allow array navigation via property with a nested grammar", done => {
-    //     const f = new InMemoryFile("Family", "Linda:[2007, mushrooms] Evelyn:[2005, sugar]");
-    //     const mg = Microgrammar.fromString<Kid>("${name}:${fact}", {
-    //         fact: Microgrammar.fromString<KidFact>("[${birthYear},${food}]", {
-    //             birthYear: Integer,
-    //         }),
-    //     });
-    //     new MicrogrammarBasedFileParser("family", "kid", mg)
-    //         .toAst(f)
-    //         .then(root => {
-    //             console.log(JSON.stringify(root, null, 2));
-    //             // Check the array property
-    //             const linda = (root as any).kids[0] as Kid & TreeNode;
-    //             assert(linda.name === "Linda", "Name=" + linda.name);
-    //             const evelyn = (root as any).kids[1] as Kid & TreeNode;
-    //             assert(evelyn.name === "Evelyn", "Name=" + evelyn.name);
-    //             // this Integer-matcher should be converting it to a number automatically. microgrammar#34
-    //             assert(+evelyn.fact.birthYear === 2005, "birth year " + evelyn.fact.birthYear );
-    //             assert(evelyn.fact.food === "sugar");
-    //             done();
-    //         }).catch(done);
-    // });
-    //
-    // it("should parse a file and keep positions", done => {
-    //     const f = new InMemoryFile("Thing", "Tom:16 Mary:25");
-    //     const mg = Microgrammar.fromString<Person>("${name}:${age}", {
-    //         age: Integer,
-    //     });
-    //     new MicrogrammarBasedFileParser("people", "person", mg)
-    //         .toAst(f)
-    //         .then(root => {
-    //             assert(root.$name === "people");
-    //             let minOffset = -1;
-    //             let terminalCount = 0;
-    //             const v: TreeVisitor = tn => {
-    //                 console.log(tn.$name + "=" + tn.$value + ",offset=" + tn.$offset);
-    //                 if (tn.$name !== "people") {
-    //                     assert(tn.$offset !== undefined, `No offset on node with name ${tn.$name}`);
-    //                     assert(tn.$offset >= minOffset, `Must have position for ${JSON.stringify(tn)}`);
-    //                     if (!!tn.$value) {
-    //                         ++terminalCount;
-    //                         // It's a terminal
-    //                         assert(f.getContentSync().substr(tn.$offset, tn.$value.length) === tn.$value,
-    //                             `Unable to validate content for ${JSON.stringify(tn)}`);
-    //                     }
-    //                     minOffset = tn.$offset;
-    //                 }
-    //                 return true;
-    //             };
-    //             visit(root, v);
-    //             assert(terminalCount > 0);
-    //             done();
-    //         }).catch(done);
-    // });
+    it("should parse a file and keep positions", done => {
+        const f = new InMemoryFile("script.ts", "const x = 1; let y = 2;");
+        new TypeScriptFileParser()
+            .toAst(f)
+            .then(root => {
+                assert(root.$name === "SourceFile");
+                let minOffset = -1;
+                let terminalCount = 0;
+                const v: TreeVisitor = tn => {
+                    console.log(tn.$name + "=" + tn.$value + ",offset=" + tn.$offset);
+                    if (tn.$name !== "people") {
+                        assert(tn.$offset !== undefined, `No offset on node with name ${tn.$name}`);
+                        assert(tn.$offset >= minOffset, `Must have position for ${JSON.stringify(tn)}`);
+                        if (!!tn.$value) {
+                            ++terminalCount;
+                            // It's a terminal
+                            assert(f.getContentSync().substr(tn.$offset, tn.$value.length) === tn.$value,
+                                `Unable to validate content for ${JSON.stringify(tn)}`);
+                        }
+                        minOffset = tn.$offset;
+                    }
+                    return true;
+                };
+                visit(root, v);
+                assert(terminalCount > 0);
+                done();
+            }).catch(done);
+    });
+
+    it("should parse project and use a path expression to find a value", done => {
+        const p = InMemoryProject.of({path: "script.ts", content: "const x = 1;"});
+        findMatches(p, new TypeScriptFileParser(),
+            "**/*.ts",
+            "//VariableDeclaration/Identifier")
+            .then(matchResults => {
+                // console.log(JSON.stringify(root, null, 2));
+                assert(matchResults.length === 1);
+                assert(matchResults[0].$value === "x");
+                done();
+            }).catch(done);
+    });
+
+    it("should parse project and use a path expression to find and update a value", done => {
+        const p = InMemoryProject.of({path: "script.ts", content: "const x = 1;"});
+        findMatches(p, new TypeScriptFileParser(),
+            "**/*.ts",
+            "//VariableDeclaration/Identifier")
+            .then(matchResults => {
+                // console.log(JSON.stringify(root, null, 2));
+                assert(matchResults.length === 1);
+                assert(matchResults[0].$value === "x");
+                matchResults[0].$value = "y";
+                p.flush().then(_ => {
+                    const f = p.findFileSync("script.ts");
+                    assert(f.getContentSync() === "const y = 1;");
+                    done();
+                });
+            }).catch(done);
+    });
 
 });

--- a/test/tree/ast/typescript/TypeScriptFileParserTest.ts
+++ b/test/tree/ast/typescript/TypeScriptFileParserTest.ts
@@ -3,6 +3,7 @@ import "mocha";
 import * as assert from "power-assert";
 import { InMemoryFile } from "../../../../src/project/mem/InMemoryFile";
 import { TypeScriptFileParser } from "../../../../src/tree/ast/typescript/TypeScriptFileParser";
+import { TreeNode } from "@atomist/tree-path/TreeNode";
 
 describe("TypeScriptFileParser", () => {
 
@@ -49,9 +50,9 @@ describe("TypeScriptFileParser", () => {
         new TypeScriptFileParser()
             .toAst(f)
             .then(root => {
-                // console.log(JSON.stringify(root, null, 2));
-                const value = evaluateExpression(root, "//VariableDeclaration/Identifier");
-                assert(value === "x");
+                const values = (evaluateExpression(root, "//Identifier") as TreeNode[])
+                    .map(n => n.$value);
+                assert.deepEqual(values, [ "x", "y"]);
                 done();
             }).catch(done);
     });


### PR DESCRIPTION
Fixes #77. Also updates `tree-path-ts` version (backward compatible).

Needs more testing, but no reason not to merge at this point as it changes no existing code and adds no dependencies.