### PR TITLE
Allow HandleCommand to return Promise<any>

### DIFF
--- a/src/HandleCommand.ts
+++ b/src/HandleCommand.ts
@@ -6,6 +6,7 @@ import { OnCommand } from "./onCommand";
  * These combine the parameters with the command. A fresh
  * instance will be created for every invocation. Prefer using the
  * parameters object to "this" in implementations of the handle method.
+ * @param P parameters type
  */
 export interface HandleCommand<P = any> {
 
@@ -17,7 +18,7 @@ export interface HandleCommand<P = any> {
     /**
      * If this method is implemented, it returns a fresh parameters instance
      * to use for this class. Otherwise will use the class itself as its parameters.
-     * @return {P}
+     * @return {P} new parameters instance
      */
     freshParametersInstance?(): P;
 

--- a/src/onCommand.ts
+++ b/src/onCommand.ts
@@ -26,16 +26,17 @@ export interface ParametersConstructor<P> {
  * parameters instance before invocation
  * @param {HandlerContext} ctx context from which GraphQL client can be obtained,
  * messages can be sent etc.
- * @return {Promise<HandlerResult>} result containing status and any command-specific data
+ * @return a Promise of a HandlerResult, containing a status code, or anything else representing
+ * success.
  */
 export type OnCommand<P = undefined> =
-    (ctx: HandlerContext, parameters: P) => Promise<HandlerResult>;
+    (ctx: HandlerContext, parameters: P) => Promise<HandlerResult> | Promise<any>;
 
 /**
  * Create a HandleCommand instance with the appropriate metadata wrapping
  * the given function
- * @param {OnCommand<P>} h
- * @param {ParametersConstructor<P>} factory
+ * @param h handle function
+ * @param {ParametersConstructor<P>} factory to create new parameters instances
  * @param {string} name can be omitted if the function isn't exported
  * @param {string} description
  * @param {string[]} intent

--- a/test/command/HelloWorld.ts
+++ b/test/command/HelloWorld.ts
@@ -1,7 +1,5 @@
 import { SlackMessage } from "@atomist/slack-messages/SlackMessages";
-import { failure, Success } from "../../src/HandlerResult";
 import { CommandHandler, Failure, HandleCommand, HandlerContext, HandlerResult, Parameter } from "../../src/index";
-import { sendMessages } from "../../src/operations/support/contextUtils";
 import { ReposQuery, ReposQueryVariables } from "../../src/schema/schema";
 import { buttonForCommand, menuForCommand } from "../../src/spi/message/MessageClient";
 import { SecretBaseHandler } from "./SecretBaseHandler";
@@ -39,13 +37,8 @@ export class HelloWorld extends SecretBaseHandler implements HandleCommand {
 
         return ctx.graphClient.executeQueryFromFile<ReposQuery, ReposQueryVariables>("graphql/repos",
             {teamId: "T1L0VDKJP", offset: 0})
-            .then(result => {
-                return Promise.resolve();
-            })
             .then(() => {
                 return ctx.messageClient.addressUsers(msg, "cd");
-            })
-            .then(() => ({code: 0, test: "some message" }), failure);
-
+            });
     }
 }

--- a/test/tree/ast/typescript/typeScriptFileParserProjectTest.ts
+++ b/test/tree/ast/typescript/typeScriptFileParserProjectTest.ts
@@ -25,7 +25,7 @@ describe("TypeScriptFileParser real project parsing: TypeScript", () => {
                     ["TypeScriptFileParser", "TypeScriptAstNodeTreeNode"]);
                 done();
             }).catch(done);
-    });
+    }).timeout(5000);
 
     it("should parse sources from project and use a path expression to find values using convenience method", done => {
         findValues(thisProject, TypeScriptES6FileParser,
@@ -36,7 +36,7 @@ describe("TypeScriptFileParser real project parsing: TypeScript", () => {
                     ["TypeScriptFileParser", "TypeScriptAstNodeTreeNode"]);
                 done();
             }).catch(done);
-    });
+    }).timeout(5000);
 
     it("should parse sources from project and find functions", done => {
         findValues(thisProject, TypeScriptES6FileParser,
@@ -46,7 +46,7 @@ describe("TypeScriptFileParser real project parsing: TypeScript", () => {
                 assert(values.length > 2);
                 done();
             }).catch(done);
-    });
+    }).timeout(5000);
 
     it("should parse sources from project and find exported functions", done => {
         findMatches(thisProject, TypeScriptES6FileParser,
@@ -56,7 +56,7 @@ describe("TypeScriptFileParser real project parsing: TypeScript", () => {
                 assert(values.length > 2);
                 done();
             }).catch(done);
-    });
+    }).timeout(5000);
 
     it("should find all exported functions in project", done => {
         findValues(thisProject, TypeScriptES6FileParser,
@@ -66,6 +66,6 @@ describe("TypeScriptFileParser real project parsing: TypeScript", () => {
                 assert(values.length > 100);
                 done();
             }).catch(done);
-    });
+    }).timeout(5000);
 
 });


### PR DESCRIPTION
Makes `HandleCommand` return `Promise<any | Promise<HandlerResult>`. The union is unnecessary but has value for documentation.

Motivation:

- The status code on `HandleResult` is rarely, if ever, used, vs using `catch`
- Additional data of value on a `HandleResult` instance could just directly come from whatever return type. Note that `handle` methods can carry a type annotation to indicate what they actually promise
- Simple handlers, in particular, are complicated by the need to translate the last promise into a `Promise<HandlerResult>`, when experience has shown that doing that doesn't add much value.

Backward compatible as far as this project is concerned, although technically could break some users (with an easy fix of adding a type annotation to the `handle` method). Most handlers declare they return `Promise<HandleResult`> anyway, and the infrastructure obviously doesn't use the status code, which tells us something.