### PR TITLE
tests pass

### DIFF
--- a/src/operations/generate/gitHubProjectPersister.ts
+++ b/src/operations/generate/gitHubProjectPersister.ts
@@ -28,8 +28,8 @@ export const GitHubProjectPersister: ProjectPersister<RepoId, Project, ActionRes
                 return gp.createAndSetGitHubRemote(params.owner, params.repo,
                     this.targetRepo, this.visibility)
                     .catch(err => {
-                        return Promise.reject(`Unable to create new repo '${params.owner}/${params.repo}': ` +
-                            `Probably exists: ${err}`);
+                        return Promise.reject(new Error(`Unable to create new repo '${params.owner}/${params.repo}': ` +
+                            `Probably exists: ${err}`));
                     });
             })
             .then(() => {

--- a/test/operations/generate/generatorEndToEndTest.ts
+++ b/test/operations/generate/generatorEndToEndTest.ts
@@ -50,11 +50,11 @@ describe("generator end to end", () => {
             });
     }
 
-    it("should create a new GitHub repo", function (done) {
+    it("should create a new GitHub repo", function(done) {
         this.retries(3);
         const repoName = tempRepoName();
         const cleanupDone = (err: Error | void) => {
-          deleteOrIgnore(repoName).then(done(err))
+          deleteOrIgnore(repoName).then(done(err));
         };
 
         const seed = new UniversalSeed();
@@ -70,16 +70,16 @@ describe("generator end to end", () => {
                         assert(r);
                         GitCommandGitProject.cloned({ token: GitHubToken },
                             new GitHubRepoRef(TargetOwner, repoName))
-                            .then(verifyPermissions)
+                            .then(verifyPermissions);
                     });
             }).then(cleanupDone, cleanupDone);
     }).timeout(20000);
 
-    it("should create a new GitHub repo using generate function", function (done) {
+    it("should create a new GitHub repo using generate function", function(done) {
         this.retries(3);
         const repoName = tempRepoName();
         const cleanupDone = (err: Error | void) => {
-            deleteOrIgnore(repoName).then(done(err))
+            deleteOrIgnore(repoName).then(done(err));
         };
 
         const clonedSeed = GitCommandGitProject.cloned({ token: GitHubToken },
@@ -97,12 +97,12 @@ describe("generator end to end", () => {
                         assert(r);
                         GitCommandGitProject.cloned({ token: GitHubToken },
                             targetRepo)
-                            .then(verifyPermissions)
+                            .then(verifyPermissions);
                     });
             }).then(cleanupDone, cleanupDone);
     }).timeout(20000);
 
-    it("should refuse to create a new GitHub repo using existing repo name", function (done) {
+    it("should refuse to create a new GitHub repo using existing repo name", function(done) {
         this.retries(5);
 
         const clonedSeed = GitCommandGitProject.cloned({ token: GitHubToken },

--- a/test/operations/generate/universalSeedMetadataTest.ts
+++ b/test/operations/generate/universalSeedMetadataTest.ts
@@ -13,12 +13,13 @@ import { Project } from "../../../src/project/Project";
 describe("UniversalSeed metadata test", () => {
 
     function validateUniversalSeedMetadata(md: CommandHandlerMetadata) {
-        assert(md.parameters.some(p => p.name === "sourceOwner"));
-        assert(md.parameters.some(p => p.name === "sourceRepo"));
+        const description = `parameters were named: ${md.parameters.map(p => p.name).join(",")}`;
+        assert(md.parameters.some(p => p.name === "sourceOwner"),description );
+        assert(md.parameters.some(p => p.name === "sourceRepo"), description);
         // assert(md.parameters.some(p=> p.name === "targetOwner"));
-        assert(md.parameters.some(p => p.name === "targetRepo"));
-        assert(md.parameters.some(p => p.name === "visibility"));
-        assert(md.parameters.some(p => p.name === "sourceBranch"));
+        assert(md.parameters.some(p => p.name === "targetRepo", description));
+        assert(md.parameters.some(p => p.name === "visibility", description));
+        assert(md.parameters.some(p => p.name === "sourceBranch", description));
         assert(md.secrets.some(s => s.name === "githubToken"));
     }
 

--- a/test/operations/generate/universalSeedMetadataTest.ts
+++ b/test/operations/generate/universalSeedMetadataTest.ts
@@ -14,7 +14,7 @@ describe("UniversalSeed metadata test", () => {
 
     function validateUniversalSeedMetadata(md: CommandHandlerMetadata) {
         const description = `parameters were named: ${md.parameters.map(p => p.name).join(",")}`;
-        assert(md.parameters.some(p => p.name === "sourceOwner"),description );
+        assert(md.parameters.some(p => p.name === "sourceOwner"), description );
         assert(md.parameters.some(p => p.name === "sourceRepo"), description);
         // assert(md.parameters.some(p=> p.name === "targetOwner"));
         assert(md.parameters.some(p => p.name === "targetRepo", description));


### PR DESCRIPTION
another test cleanup pass.

Use different temp repo names so the tests don't interfere with each other.

the univeralmetadataTest is just some error messaging that was usefl, might as well leave it in there