### PR TITLE
use a repo in atomist-travisorg for testing clone

### DIFF
--- a/test/operations/generate/generatorEndToEndTest.ts
+++ b/test/operations/generate/generatorEndToEndTest.ts
@@ -107,8 +107,7 @@ describe("generator end to end", () => {
 
         const clonedSeed = GitCommandGitProject.cloned({ token: GitHubToken },
             new GitHubRepoRef("atomist-seeds", "spring-rest-seed"));
-        const targetRepo = new GitHubRepoRef("johnsonr", "wallaby"); // never delete wallaby. this test will fail.
-        // TODO: make a repo called repo-that-exists in travisorg instead
+        const targetRepo = new GitHubRepoRef("atomist-travisorg", "this-repository-exists");
 
         generate(clonedSeed, undefined, { token: GitHubToken },
             p => Promise.resolve(p), GitHubProjectPersister,


### PR DESCRIPTION
because we don't need to depend on Rod's personal repositories.
He could delete wallaby someday, this is not farfetched