### PR TITLE
Create a unified atomist CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "compile:cortex": "ncp src/graph/schema.cortex.json build/src/graph/schema.cortex.json",
     "compile:ts": "tsc --project .",
     "fmt": "tsfmt --replace",
-    "git:info": "node  --trace-warnings build/src/git.info.js",
+    "git:info": "node build/src/scripts/git-info.js",
     "lint": "tslint --format verbose --project . --exclude '{build,node_modules}/**' '**/*.ts'",
     "lint:fix": "npm run lint -- --fix",
     "start": "npm-run-all git:info start:server",
@@ -144,10 +144,11 @@
     "watch:server": "supervisor --watch build --quiet --exec npm -- run start:server"
   },
   "bin": {
-    "git-info": "./git.info.js",
-    "atomist-cli": "./start.cli.js",
-    "atomist-client": "./start.client.js",
-    "atomist-config": "./atomist.setup.js"
+    "atomist": "./start.cli.js",
+    "git-info": "./git-info.js",
+    "atomist-cli": "./atomist-cli.js",
+    "atomist-client": "./atomist-client.js",
+    "atomist-config": "./atomist-config.js"
   },
   "engines": {
     "node": "8.x.x",

--- a/src/atomist-cli.ts
+++ b/src/atomist-cli.ts
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+import * as child_process from "child_process";
+import * as process from "process";
+console.warn("atomist-cli is deprecated, use 'atomist' instead");
+child_process.execFileSync("atomist", process.argv, { env: process.env, stdio: "inherit" });

--- a/src/atomist-client.ts
+++ b/src/atomist-client.ts
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+import * as child_process from "child_process";
+import * as process from "process";
+console.warn("atomist-client is deprecated, use 'atomist start' instead");
+process.argv.unshift("start");
+child_process.execFileSync("atomist", process.argv, { env: process.env, stdio: "inherit" });

--- a/src/atomist-config.ts
+++ b/src/atomist-config.ts
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+import * as child_process from "child_process";
+import * as process from "process";
+console.warn("atomist-config is deprecated, use 'atomist config' instead");
+process.argv.unshift("config");
+child_process.execFileSync("atomist", process.argv, { env: process.env, stdio: "inherit" });

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -1,0 +1,108 @@
+import * as child_process from "child_process";
+import * as fs from "fs";
+import * as p from "path";
+import { CommandInvocation } from "../internal/invoker/Payload";
+import { logger } from "../internal/util/logger";
+
+export function start(path: string,
+                      runInstall: boolean = true,
+                      runCompile: boolean = true) {
+    const ap = resolve(path);
+    path = `${ap}/node_modules/@atomist/automation-client/start.client.js`;
+
+    if (!fs.existsSync(p.join(ap, "node_modules")) && runInstall) {
+        install(ap);
+    }
+
+    if (!fs.existsSync(path)) {
+        logger.error(`Project at '${ap}' is not a valid automation client project`);
+        process.exit(1);
+    }
+
+    if (runCompile) {
+        compile(ap);
+    }
+
+    logger.info(`Starting Automation Client in '${ap}'\n`);
+    try {
+        child_process.execSync(`node $ATOMIST_NODE_OPTIONS ${path}`,
+            { cwd: ap, stdio: "inherit", env: process.env });
+    } catch (e) {
+        process.exit(e.status);
+    }
+}
+
+export function run(path: string,
+                    ci: CommandInvocation,
+                    runInstall: boolean = true,
+                    runCompile: boolean = true) {
+    const ap = resolve(path);
+    path = `${ap}/node_modules/@atomist/automation-client/cli/run.js`;
+
+    if (!fs.existsSync(p.join(ap, "node_modules")) && runInstall) {
+        install(ap);
+    }
+
+    if (!fs.existsSync(path)) {
+        logger.error(`Project at '${ap}' is not a valid automation client project`);
+        process.exit(1);
+    }
+
+    if (runCompile) {
+        compile(ap);
+    }
+
+    logger.info(`Running command '${ci.name}' in '${ap}'\n`);
+    try {
+        child_process.execSync(`node $ATOMIST_NODE_OPTIONS ${path} --request='${JSON.stringify(ci)}'`,
+            { cwd: ap, stdio: "inherit", env: process.env });
+        process.exit(0);
+    } catch (e) {
+        process.exit(e.status);
+    }
+}
+
+export function config() {
+    const script = p.resolve(__dirname, "config.js");
+    child_process.execSync(`node ${script}`,
+        { cwd: process.cwd(), stdio: "inherit", env: process.env });
+}
+
+export function gitInfo(path: string) {
+    const script = p.resolve(__dirname, "git-info.js");
+    child_process.execSync(`node ${script}`,
+        { cwd: process.cwd(), stdio: "inherit", env: process.env });
+}
+
+export function install(path: string) {
+    logger.info(`Running 'npm install' in '${path}'`);
+    try {
+        checkPackageJson(path);
+        child_process.execSync(`npm install`,
+            {cwd: path, stdio: "inherit", env: process.env});
+    } catch (e) {
+        process.exit(e.status);
+    }
+}
+
+export function compile(path: string) {
+    logger.info(`Running 'npm run compile' in '${path}'`);
+    try {
+        checkPackageJson(path);
+        child_process.execSync(`npm run compile`,
+            {cwd: path, stdio: "inherit", env: process.env});
+    } catch (e) {
+        process.exit(e.status);
+    }
+}
+
+export function checkPackageJson(path: string) {
+    if (!fs.existsSync(p.join(path, "package.json"))) {
+        logger.error(`No 'package.json' in '${path}'`);
+        process.exit(1);
+    }
+}
+
+export function resolve(path: string): string {
+    return p.resolve(process.cwd(), path);
+}

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -1,15 +1,19 @@
 #!/usr/bin/env node
 
+import { LoggingConfig } from "../internal/util/logger";
+process.env.SUPPRESS_NO_CONFIG_WARNING = "true";
+LoggingConfig.format = "cli";
+
 import * as fs from "fs-extra";
 import * as GitHubApi from "github";
 import * as inquirer from "inquirer";
 import * as os from "os";
-import * as process from "process";
 
-import { UserConfigFile, writeUserConfig } from "./configuration";
-import { LoggingConfig } from "./internal/util/logger";
+import {
+    UserConfigFile,
+    writeUserConfig,
+} from "../configuration";
 
-LoggingConfig.format = "cli";
 const github = new GitHubApi();
 
 function createGitHubToken(user: string, password: string, mfa?: string): Promise<string> {
@@ -38,7 +42,7 @@ function createGitHubToken(user: string, password: string, mfa?: string): Promis
 function atomistConfig(argv: string[]) {
 
     if (fs.existsSync(UserConfigFile)) {
-        console.warn(`user configuration file, ${UserConfigFile}, already exists, exiting`);
+        console.warn(`User configuration file, ${UserConfigFile}, already exists, exiting`);
         process.exit(0);
     }
 
@@ -140,7 +144,7 @@ nor your GitHub username and password.
                         process.exit(1);
                     });
             } else {
-                console.error(`failed to generate GitHub token with provided credentials`);
+                console.error(`Failed to generate GitHub token with provided credentials`);
                 process.exit(1);
             }
         }
@@ -149,10 +153,10 @@ nor your GitHub username and password.
             teamIds: [slackTeamId],
         });
     }).then(() => {
-        console.info(`successfully created Atomist user config`);
+        console.info(`Successfully created Atomist user configuration`);
         process.exit(0);
     }).catch(err => {
-        console.error(`failed to create user config: ${JSON.stringify(err)}`);
+        console.error(`Failed to create user config: ${JSON.stringify(err)}`);
         process.exit(1);
     });
 }

--- a/src/cli/git-info.ts
+++ b/src/cli/git-info.ts
@@ -1,7 +1,12 @@
 #!/usr/bin/env node
+
+import { LoggingConfig } from "../internal/util/logger";
+process.env.SUPPRESS_NO_CONFIG_WARNING = "true";
+LoggingConfig.format = "cli";
+
 import * as appRoot from "app-root-path";
 import { writeFile } from "fs";
-import { obtainGitInfo } from "./internal/env/gitInfo";
+import { obtainGitInfo } from "../internal/env/gitInfo";
 
 obtainGitInfo(appRoot.path)
     .then(result => {

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+
+import { LoggingConfig } from "../internal/util/logger";
+process.env.SUPPRESS_NO_CONFIG_WARNING = "true";
+LoggingConfig.format = "cli";
+
+import * as yargs from "yargs";
+import { automationClient } from "../automationClient";
+import {
+    Configuration,
+    findConfiguration,
+} from "../configuration";
+import { HandlerContext } from "../HandlerContext";
+import { CommandInvocation } from "../internal/invoker/Payload";
+import { consoleMessageClient } from "../internal/message/ConsoleMessageClient";
+import { guid } from "../internal/util/string";
+
+import { AutomationServer } from "../server/AutomationServer";
+
+if (yargs.argv.request) {
+    try {
+        const request: CommandInvocation = JSON.parse(yargs.argv.request);
+        const config = findConfiguration();
+        const node = automationClient(config);
+
+        if (config.commands) {
+            config.commands.forEach(c => {
+                node.withCommandHandler(c);
+            });
+        }
+
+        invokeOnConsole(node.automationServer, request, createHandlerContext(config));
+    } catch (e) {
+        console.error(`Error: ${e.message}`);
+        process.exit(1);
+    }
+} else {
+    console.log("Error: Missing command request");
+    process.exit(1);
+}
+
+function createHandlerContext(config: Configuration): HandlerContext {
+    return {
+        teamId: config.teamIds[0],
+        correlationId: guid(),
+        messageClient: consoleMessageClient,
+    };
+}
+
+function invokeOnConsole(automationServer: AutomationServer, ci: CommandInvocation, ctx: HandlerContext) {
+
+    // Set up the parameter, mappend parameters and secrets
+    const handler = automationServer.automations.commands.find(c => c.name === ci.name);
+    const invocation: CommandInvocation = {
+        name: ci.name,
+        args: ci.args ? ci.args.filter(a =>
+            handler.parameters.some(p => p.name === a.name)) : undefined,
+        mappedParameters: ci.args ? ci.args.filter(a =>
+            handler.mapped_parameters.some(p => p.local_key === a.name)) : undefined,
+        secrets: ci.args ? ci.args.filter(a => handler.secrets.some(p => p.name === a.name))
+            .map(a => {
+                const s = handler.secrets.find(p => p.name === a.name);
+                return { name: s.path, value: a.value};
+            }) : undefined,
+    };
+
+    try {
+        automationServer.validateCommandInvocation(invocation);
+    } catch (e) {
+        console.log("Error: Invalid parameters: %s", e.message);
+        process.exit(1);
+    }
+    try {
+        automationServer.invokeCommand(invocation, ctx)
+            .then(r => {
+                console.log(`Command succeeded: ${JSON.stringify(r, null, 2)}`);
+                process.exit(0);
+            })
+            .catch(err => {
+                console.log(`Error: Command failed: ${JSON.stringify(err, null, 2)}`);
+                process.exit(1);
+            });
+    } catch (e) {
+        console.log("Error: Command failed: %s", e.message);
+        process.exit(1);
+    }
+}

--- a/src/git-info.ts
+++ b/src/git-info.ts
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+import * as child_process from "child_process";
+import * as process from "process";
+console.warn("git-info is deprecated, use 'atomist git' instead");
+process.argv.unshift("git");
+child_process.execFileSync("atomist", process.argv, { env: process.env, stdio: "inherit" });

--- a/src/start.cli.ts
+++ b/src/start.cli.ts
@@ -1,63 +1,111 @@
 #!/usr/bin/env node
 
-import * as yargs from "yargs";
-import { automationClient } from "./automationClient";
-import { findConfiguration } from "./configuration";
-import { HandlerContext } from "./HandlerContext";
-import { Arg, CommandInvocation } from "./internal/invoker/Payload";
-import { consoleMessageClient } from "./internal/message/ConsoleMessageClient";
-import { guid } from "./internal/util/string";
-import { enableDefaultScanning } from "./scan";
-import { AutomationServer } from "./server/AutomationServer";
+import { LoggingConfig } from "./internal/util/logger";
+process.env.SUPPRESS_NO_CONFIG_WARNING = "true";
+LoggingConfig.format = "cli";
 
-const config  = enableDefaultScanning(findConfiguration());
-const node = automationClient(config);
+import * as yargs from "yargs";
+import {
+    config,
+    gitInfo,
+    run,
+    start,
+} from "./cli/commands";
+import {
+    CommandInvocation,
+} from "./internal/invoker/Payload";
 
 // tslint:disable-next-line:no-unused-expression
 yargs.completion("completion")
-    .command("run", "Run a command", ya => {
-        return ya.option("command", {
-            describe: "Command name",
-        });
+    .command(["execute <name>", "exec <name>", "cmd <name>"], "Run a command", ya => {
+        // positional is not yet supported in @types/yargs
+        return (ya as any).positional("name", {
+            describe: "Name of command to run",
+            required: true,
+        })
+        .option("change-dir", {
+            alias: "C",
+            describe: "Path to automation client project",
+            required: false,
+            default: process.cwd(),
+        })
+        .boolean("compile")
+        .default("compile", true )
+        .describe("compile", "Run 'npm run compile'")
+        .boolean("install")
+        .default("install", true)
+        .describe("install", "Run 'npm install'");
     }, argv => {
         const args = extractArgs(argv);
         const ci: CommandInvocation = {
-            name: argv.command,
+            name: argv.name,
             args,
         };
-        invokeOnConsole(node.automationServer, ci, createHandlerContext());
+        try {
+            run(argv["change-dir"], ci, argv.install, argv.compile);
+        } catch (e) {
+            console.log("Error: %s", e.message);
+            process.exit(1);
+        }
     })
+    .command(["start", "st", "run"], "Start an automation client", ya => {
+        return ya.option("change-dir", {
+            alias: "C",
+            describe: "Path to automation client project",
+            required: false,
+            default: process.cwd(),
+        })
+        .boolean("compile")
+        .default("compile", true )
+        .describe("compile", "Run 'npm run compile'")
+        .boolean("install")
+        .default("install", true)
+        .describe("install", "Run 'npm install'");
+    }, argv => {
+        try {
+            start(argv["change-dir"], argv.install, argv.compile);
+        } catch (e) {
+            console.log("Error: %s", e.message);
+            process.exit(1);
+        }
+
+    })
+    .command("git", "Create a git-info.json file", ya => {
+        return ya.option("change-dir", {
+            alias: "C",
+            describe: "Path to automation client project",
+            required: false,
+            default: process.cwd(),
+        });
+    }, argv => {
+        gitInfo(argv.path);
+    })
+    .command("config", "Configure environment for running automation clients", ya => {
+        return ya;
+    }, argv => {
+        config();
+    })
+    .showHelpOnFail(false, "Specify --help for available options")
+    .alias("h", "help")
+    .alias("?", "help")
+    .version(readVersion())
+    .alias("v", "version")
+    .describe("version", "Show version information")
     .argv;
 
-function createHandlerContext(): HandlerContext {
-    return {
-        teamId: config.teamIds[0],
-        correlationId: guid(),
-        messageClient: consoleMessageClient,
-    };
-}
-
-function extractArgs(args): Arg[] {
+function extractArgs(args) {
     return Object.getOwnPropertyNames(args)
-        .filter(k => !(k.includes("$") || k.includes("_")))
+        // .filter(k => !(k.includes("$") || k.includes("_")))
         .map(k => {
-            return { name: k, value: args[k] };
+            return {name: k, value: args[k]};
         });
 }
 
-function invokeOnConsole(automationServer: AutomationServer, ci: CommandInvocation, ctx: HandlerContext) {
+function readVersion(): string {
     try {
-        automationServer.validateCommandInvocation(ci);
+        const pj = require("../package.json");
+        return `${pj.name} ${pj.version}`;
     } catch (e) {
-        console.log("Invalid parameters: %s", e.message);
-        process.exit(1);
+        return "@atomist/automation-client 0.0.0";
     }
-    automationServer.invokeCommand(ci, ctx)
-        .then(r => {
-            console.log(`Command succeeded: ${JSON.stringify(r, null, 2)}`);
-        })
-        .catch(err => {
-            console.log(`Command failed: ${JSON.stringify(err, null, 2)}`);
-            process.exit(1);
-        });
 }


### PR DESCRIPTION
Move current commands into single CLI.  Organize CLI code into cli
folder.  Disable logging for CLI.  Add help and version command-line
options.  Add compile and install options to start, exiting gracefully
if there is no package.json.