### PR TITLE
Fix #34: Add nested parameter support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+-   `generate` utility function now takes `RepoId` argument before optional params
 -   Split out tests into test and test-api so non-Atomist developers
-    could run non-API tests
+    can run non-API tests
 -   Improve `atomist config` handling of existing config file so it
     can be used to add additional teams
 -   Run `config` and `git` commands in same node process

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 [Unreleased]: https://github.com/atomist/automation-client-ts/compare/0.3.2...HEAD
 
+### Added
+
+-   Support for nested parameters via initialized object properties on parameters
+
 ### Changed
 
 -   Split out tests into test and test-api so non-Atomist developers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 -   Run `config` and `git` commands in same node process
 -   Added "repo" scope to GitHub personal access token created by
     `config` since so many sample automations require it
+-   @Parameter() will default to empty options, so you don't have to pass {}
 
 ## [0.3.2][] - 2017-11-13
 

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -13,7 +13,7 @@ import { toStringArray } from "./internal/util/string";
 /**
  * Decorator for parameters. Adds to object properties
  */
-export function Parameter(details: BaseParameter) {
+export function Parameter(details: BaseParameter = {}) {
     return (target: any, propertyKey: string) => {
         declareParameter(target, propertyKey, details);
     };

--- a/src/internal/parameterPopulation.ts
+++ b/src/internal/parameterPopulation.ts
@@ -1,59 +1,65 @@
-import { Chooser, CommandHandlerMetadata, FreeChoices } from "../metadata/automationMetadata";
+import { Chooser, CommandHandlerMetadata, FreeChoices, Parameter } from "../metadata/automationMetadata";
 import { Arg } from "./invoker/Payload";
+
+import * as _ from "lodash";
 
 /**
  * Populate the parameters of the command handler instance,
  * performing type coercion if necessary
- * @param h parameters instance (may be handler instance itself)
+ * @param instanceToPopulate parameters instance (may be handler instance itself)
  * @param hm handler metadata
  * @param args string args
  */
-export function populateParameters(h: any, hm: CommandHandlerMetadata, args: Arg[]) {
+export function populateParameters(instanceToPopulate: any, hm: CommandHandlerMetadata, args: Arg[]) {
     args.forEach(arg => {
         if (arg.value !== undefined) {
             const parameter = hm.parameters.find(p => p.name === arg.name);
             if (parameter) {
-                // Convert type if necessary
-                let value;
-                switch (parameter.type) {
-                    case undefined :
-                        // It's a string. Keep the value the same
-                        value = arg.value;
-                        break;
-                    case FreeChoices :
-                        // It's a string array. Keep the value the same
-                        value = arg.value;
-                        break;
-                    case "boolean":
-                        value = arg.value === "true";
-                        break;
-                    case "number":
-                        if (typeof arg.value === "string") {
-                            value = parseInt(arg.value, 10);
-                        } else {
-                            throw new Error(`Parameter '${parameter.name}' has array value, but is numeric`);
-                        }
-                        break;
-                    default:
-                        // It's a Chooser
-                        const chooser = parameter.type as Chooser;
-                        if (chooser.pickOne) {
-                            if (typeof arg.value !== "string") {
-                                throw new Error(`Parameter '${parameter.name}' has array value, but should be string`);
-                            }
-                            // Treat as a string
-                            value = arg.value;
-                        } else {
-                            if (typeof arg.value === "string") {
-                                throw new Error(`Parameter '${parameter.name}' has string value, but should be array`);
-                            }
-                            // It's an array
-                            value = arg.value;
-                        }
-                        break;
-                }
-                h[arg.name] = value;
+                _.update(instanceToPopulate, parameter.name, () => computeValue(parameter, arg));
             }
         }
     });
+}
+
+function computeValue(parameter: Parameter, arg: Arg) {
+    let value;
+    // Convert type if necessary
+    switch (parameter.type) {
+        case undefined :
+            // It's a string. Keep the value the same
+            value = arg.value;
+            break;
+        case FreeChoices :
+            // It's a string array. Keep the value the same
+            value = arg.value;
+            break;
+        case "boolean":
+            value = arg.value === "true";
+            break;
+        case "number":
+            if (typeof arg.value === "string") {
+                value = parseInt(arg.value, 10);
+            } else {
+                throw new Error(`Parameter '${parameter.name}' has array value, but is numeric`);
+            }
+            break;
+        default:
+            // It's a Chooser
+            const chooser = parameter.type as Chooser;
+            if (chooser.pickOne) {
+                if (typeof arg.value !== "string") {
+                    throw new Error(`Parameter '${parameter.name}' has array value, but should be string`);
+                }
+                // Treat as a string
+                value = arg.value;
+            } else {
+                if (typeof arg.value === "string") {
+                    throw new Error(`Parameter '${parameter.name}' has string value, but should be array`);
+                }
+                // It's an array
+                value = arg.value;
+            }
+            break;
+    }
+    return value;
 }

--- a/src/operations/common/params/SourceRepoParameters.ts
+++ b/src/operations/common/params/SourceRepoParameters.ts
@@ -14,7 +14,7 @@ export class SourceRepoParameters {
         description: "owner, i.e., user or organization, of seed repository",
         validInput: GitHubNameRegExp.validInput,
         minLength: 1,
-        maxLength: 50,
+        maxLength: 100,
         required: false,
         displayable: false,
     })
@@ -26,7 +26,7 @@ export class SourceRepoParameters {
         description: "name of the seed repository",
         validInput: GitHubNameRegExp.validInput,
         minLength: 1,
-        maxLength: 50,
+        maxLength: 100,
         required: false,
         displayable: false,
     })
@@ -38,7 +38,7 @@ export class SourceRepoParameters {
         description: "seed repository branch to clone for new project",
         validInput: GitBranchRegExp.validInput,
         minLength: 1,
-        maxLength: 50,
+        maxLength: 256,
         required: false,
         displayable: false,
     })

--- a/src/operations/common/params/SourceRepoParameters.ts
+++ b/src/operations/common/params/SourceRepoParameters.ts
@@ -1,18 +1,12 @@
-import { Parameter } from "../../decorators";
-import { HandlerContext } from "../../index";
-import { Project } from "../../project/Project";
-import { GitHubRepoRef } from "../common/GitHubRepoRef";
-import { GitBranchRegExp, GitHubNameRegExp } from "../common/params/gitHubPatterns";
-import { AbstractGenerator } from "./AbstractGenerator";
+
+import { Parameter } from "../../../decorators";
+import { GitBranchRegExp, GitHubNameRegExp } from "./gitHubPatterns";
 
 /**
- * Support for all seed-driven generators, which start with content
- * in a given repo.
- *
- * Defines common parameters.
- *
+ * Parameters common to anything that works with a single source repo,
+ * such as a seed driven generator
  */
-export abstract class SeedDrivenGenerator extends AbstractGenerator {
+export class SourceRepoParameters {
 
     @Parameter({
         pattern: GitHubNameRegExp.pattern,
@@ -49,10 +43,5 @@ export abstract class SeedDrivenGenerator extends AbstractGenerator {
         displayable: false,
     })
     public sourceBranch: string = "master";
-
-    public startingPoint(ctx: HandlerContext, params: this): Promise<Project> {
-        return this.repoLoader()(
-            new GitHubRepoRef(this.sourceOwner, this.sourceRepo, this.sourceBranch));
-    }
 
 }

--- a/src/operations/common/params/gitHubPatterns.ts
+++ b/src/operations/common/params/gitHubPatterns.ts
@@ -1,0 +1,12 @@
+
+export const GitHubNameRegExp = {
+    pattern: /^[-.\w]+$/,
+    validInput: "a valid GitHub identifier which consists of alphanumeric, ., -, and _ characters",
+};
+
+export const GitBranchRegExp = {
+    // not perfect, but pretty good
+    pattern: /^\w([-.\w]*[-\w])*(\w([-.\w]*[-\w])*)*$/,
+    validInput: "a valid Git branch name, see" +
+    " https://www.kernel.org/pub/software/scm/git/docs/git-check-ref-format.html",
+};

--- a/src/operations/generate/AbstractGenerator.ts
+++ b/src/operations/generate/AbstractGenerator.ts
@@ -13,14 +13,10 @@ import { NodeFsLocalProject } from "../../project/local/NodeFsLocalProject";
 import { Project } from "../../project/Project";
 import { defaultRepoLoader } from "../common/defaultRepoLoader";
 import { LocalOrRemote } from "../common/LocalOrRemote";
+import { GitHubNameRegExp } from "../common/params/gitHubPatterns";
 import { RepoLoader } from "../common/repoLoader";
 import { AnyProjectEditor, ProjectEditor, toEditor } from "../edit/projectEditor";
 import { push } from "./gitHubProjectPersister";
-
-export const GitHubNameRegExp = {
-    pattern: /^[-.\w]+$/,
-    validInput: "a valid GitHub identifier which consists of alphanumeric, ., -, and _ characters",
-};
 
 /**
  * Support for all generators.

--- a/src/operations/generate/NewRepoCreationParameters.ts
+++ b/src/operations/generate/NewRepoCreationParameters.ts
@@ -29,7 +29,6 @@ export class NewRepoCreationParameters implements RepoId {
     @Parameter({
         displayName: "Project Description",
         description: "short descriptive text describing the new project",
-        pattern: /.*/,
         validInput: "free text",
         minLength: 1,
         maxLength: 100,

--- a/src/operations/generate/NewRepoCreationParameters.ts
+++ b/src/operations/generate/NewRepoCreationParameters.ts
@@ -1,11 +1,12 @@
 
 import { MappedParameter, MappedParameters, Parameter, Secret, Secrets } from "../../decorators";
 import { GitHubNameRegExp } from "../common/params/gitHubPatterns";
+import { RepoId } from "../common/RepoId";
 
 /**
  * Parameters common to all generators that create new repositories
  */
-export class NewRepoCreationParameters {
+export class NewRepoCreationParameters implements RepoId {
 
     @Secret(Secrets.userToken(["repo", "user"]))
     public githubToken;
@@ -46,5 +47,13 @@ export class NewRepoCreationParameters {
         required: false,
     })
     public visibility: "public" | "private" = "public";
+
+    get owner() {
+        return this.targetOwner;
+    }
+
+    get repo() {
+        return this.targetRepo;
+    }
 
 }

--- a/src/operations/generate/NewRepoCreationParameters.ts
+++ b/src/operations/generate/NewRepoCreationParameters.ts
@@ -20,7 +20,7 @@ export class NewRepoCreationParameters implements RepoId {
         description: "name of the target repository",
         validInput: GitHubNameRegExp.validInput,
         minLength: 1,
-        maxLength: 50,
+        maxLength: 100,
         required: true,
         order: 1,
     })

--- a/src/operations/generate/NewRepoCreationParameters.ts
+++ b/src/operations/generate/NewRepoCreationParameters.ts
@@ -1,0 +1,50 @@
+
+import { MappedParameter, MappedParameters, Parameter, Secret, Secrets } from "../../decorators";
+import { GitHubNameRegExp } from "../common/params/gitHubPatterns";
+
+/**
+ * Parameters common to all generators that create new repositories
+ */
+export class NewRepoCreationParameters {
+
+    @Secret(Secrets.userToken(["repo", "user"]))
+    public githubToken;
+
+    @MappedParameter(MappedParameters.GitHubOwner)
+    public targetOwner: string;
+
+    @Parameter({
+        pattern: GitHubNameRegExp.pattern,
+        displayName: "Target Repository Name",
+        description: "name of the target repository",
+        validInput: GitHubNameRegExp.validInput,
+        minLength: 1,
+        maxLength: 50,
+        required: true,
+        order: 1,
+    })
+    public targetRepo: string;
+
+    @Parameter({
+        displayName: "Project Description",
+        description: "short descriptive text describing the new project",
+        pattern: /.*/,
+        validInput: "free text",
+        minLength: 1,
+        maxLength: 100,
+        required: false,
+    })
+    public description: string = "my new project";
+
+    @Parameter({
+        displayName: "Repository Visibility",
+        description: "visibility of the new repository (public or private; defaults to public)",
+        pattern: /^(public|private)$/,
+        validInput: "public or private",
+        minLength: 6,
+        maxLength: 7,
+        required: false,
+    })
+    public visibility: "public" | "private" = "public";
+
+}

--- a/src/operations/generate/SeedDrivenRepoGenerationParameters.ts
+++ b/src/operations/generate/SeedDrivenRepoGenerationParameters.ts
@@ -1,0 +1,13 @@
+
+import { SourceRepoParameters } from "../common/params/SourceRepoParameters";
+import { NewRepoCreationParameters } from "./NewRepoCreationParameters";
+
+/**
+ * The parameters needed to create a new repo from a seed
+ */
+export class SeedDrivenRepoGenerationParameters {
+
+    public source = new SourceRepoParameters();
+
+    public target = new NewRepoCreationParameters();
+}

--- a/src/operations/generate/generatorUtils.ts
+++ b/src/operations/generate/generatorUtils.ts
@@ -15,11 +15,12 @@ import { AnyProjectEditor, ProjectEditor, toEditor } from "../edit/projectEditor
  * Function that knows how to persist a project using the given credentials.
  * Can take parameters and return a subclass of action result.
  */
-export type ProjectPersister<PARAMS = undefined, P extends Project = Project,
+export type ProjectPersister<P extends Project = Project,
     R extends ActionResult<P> = ActionResult<P>> =
     (p: Project,
      credentials: ProjectOperationCredentials,
-     params?: PARAMS) => Promise<R>;
+     targetId: RepoId,
+     params?: object) => Promise<R>;
 
 /**
  * Generate a new project given the starting point project.
@@ -28,33 +29,33 @@ export type ProjectPersister<PARAMS = undefined, P extends Project = Project,
  * @param {HandlerContext} ctx
  * @param {ProjectOperationCredentials} credentials
  * @param {ProjectEditor} editor editor that does the actual transformation
- * @param {ProjectPersister<PARAMS>} persist function to persist the new project:
+ * @param persist persist function to persist the new project:
  * for example, to GitHub
- * @param {PARAMS} params - contain repo identification for persistence
- * @return {Promise<R>}
+ * @param targetId id of target repo for persistence
+ * @param params - optional parameters to be passed to persister
  */
-export function generate<PARAMS extends RepoId,
-    R extends ActionResult<Project> = ActionResult<Project>>(startingPoint: Promise<Project> | Project,
-                                                             ctx: HandlerContext,
-                                                             credentials: ProjectOperationCredentials,
-                                                             editor: AnyProjectEditor<any>,
-                                                             persist: ProjectPersister<PARAMS, Project, R>,
-                                                             params: PARAMS): Promise<R> {
+export function generate(startingPoint: Promise<Project> | Project,
+                         ctx: HandlerContext,
+                         credentials: ProjectOperationCredentials,
+                         editor: AnyProjectEditor,
+                         persist: ProjectPersister,
+                         targetId: RepoId,
+                         params?: object): Promise<ActionResult<Project>> {
     const parentDir = DefaultDirectoryManager.opts.baseDir;
     logger.debug("Independent copy of seed will be at %s/%s: owner/repo=%s:%s",
-        parentDir, params.repo, params.owner, params.repo);
-    return fs.remove(parentDir + "/" + params.repo)
+        parentDir, targetId.repo, targetId.owner, targetId.repo);
+    return fs.remove(parentDir + "/" + targetId.repo)
         .then(() => Promise.resolve(startingPoint)
             .then(seed =>
                 // Make a copy that we can work on
-                NodeFsLocalProject.copy(seed, parentDir, params.repo))
+                NodeFsLocalProject.copy(seed, parentDir, targetId.repo))
             // Let's be sure we didn't inherit any old git stuff
             .then(proj => proj.deleteDirectory(".git"))
-            .then(independentCopy => toEditor(editor)(independentCopy, ctx, params))
+            .then(independentCopy => toEditor<object>(editor)(independentCopy, ctx, params))
             .then(r => r.target)
             .then(populated => {
                 logger.debug("Persisting repo at [%s]: owner/repo=%s:%s",
-                    (populated as LocalProject).baseDir, params.owner, params.repo);
-                return persist(populated, credentials, params);
+                    (populated as LocalProject).baseDir, targetId.owner, targetId.repo);
+                return persist(populated, credentials, targetId);
             }));
 }

--- a/src/operations/generate/gitHubProjectPersister.ts
+++ b/src/operations/generate/gitHubProjectPersister.ts
@@ -12,23 +12,23 @@ import { ProjectPersister } from "./generatorUtils";
  * Persist project to GitHub, returning GitHub details. Use retry.
  * @param {Project} p project to persist
  * @param {ProjectOperationCredentials} creds
- * @param {RepoId} params
+ * @param targetId id of target repo to create
  * @return {Promise<ActionResult<GitProject>>}
  */
-export const GitHubProjectPersister: ProjectPersister<RepoId, Project, ActionResult<GitProject>> =
+export const GitHubProjectPersister: ProjectPersister<GitProject> =
     (p: Project,
      creds: ProjectOperationCredentials,
-     params: RepoId) => {
+     targetId: RepoId) => {
         const gp: GitProject =
             GitCommandGitProject.fromProject(p, creds);
         return gp.init()
             .then(() => gp.setGitHubUserConfig())
             .then(() => {
-                logger.debug(`Creating new repo '${params.owner}/${params.repo}'`);
-                return gp.createAndSetGitHubRemote(params.owner, params.repo,
+                logger.debug(`Creating new repo '${targetId.owner}/${targetId.repo}'`);
+                return gp.createAndSetGitHubRemote(targetId.owner, targetId.repo,
                     this.targetRepo, this.visibility)
                     .catch(err => {
-                        return Promise.reject(new Error(`Unable to create new repo '${params.owner}/${params.repo}': ` +
+                        return Promise.reject(new Error(`Unable to create new repo '${targetId.owner}/${targetId.repo}': ` +
                             `Probably exists: ${err}`));
                     });
             })

--- a/src/operations/generate/java/JavaSeed.ts
+++ b/src/operations/generate/java/JavaSeed.ts
@@ -78,7 +78,7 @@ export class JavaSeed extends UniversalSeed implements VersionedArtifact {
         validInput: "a valid Java package name, which consists of period-separated identifiers which" +
         " have only alphanumeric characters, $ and _ and do not start with a number",
         minLength: 1,
-        maxLength: 50,
+        maxLength: 150,
         required: true,
         order: 53,
     })

--- a/test/internal/metadata/classWithExternalParametersMetadataReadingTest.ts
+++ b/test/internal/metadata/classWithExternalParametersMetadataReadingTest.ts
@@ -7,6 +7,7 @@ import { HandleCommand } from "../../../src/HandleCommand";
 import { HandlerContext } from "../../../src/HandlerContext";
 import { MappedParameters } from "../../../src/index";
 import { CommandHandlerMetadata } from "../../../src/metadata/automationMetadata";
+import { GitHubRepoRef } from "../../../src/operations/common/GitHubRepoRef";
 
 describe("class with external parameters metadata reading", () => {
 
@@ -23,7 +24,7 @@ describe("class with external parameters metadata reading", () => {
         assert(md.secrets[0].path === "atomist://some_secret");
     });
 
-    it("should extract metadata from command handler with external parameters", () => {
+    it("should extract metadata from command handler with external nested parameters", () => {
         const h = new AddAtomistSpringAgentWithComposedParameters();
         const md = metadataFromInstance(h) as CommandHandlerMetadata;
         assert(md.parameters.length === 1);
@@ -33,6 +34,74 @@ describe("class with external parameters metadata reading", () => {
         assert(md.mapped_parameters[0].foreign_key === "atomist://github_url");
         assert(md.secrets.length === 1);
         assert(md.secrets[0].name === "secrets.someSecret");
+        assert(md.secrets[0].path === "atomist://some_secret");
+    });
+
+    it("should extract metadata from command handler with direct nested parameters", () => {
+        const h = new AddAtomistSpringAgentWithComposedParametersDirectlyOnHandler();
+        const md = metadataFromInstance(h) as CommandHandlerMetadata;
+        assert(md.parameters.length === 1);
+        assert(md.parameters[0].name === "params.slackTeam");
+        assert(md.mapped_parameters.length === 2);
+        assert(md.mapped_parameters[0].local_key === "params.githubWebUrl");
+        assert(md.mapped_parameters[0].foreign_key === "atomist://github_url");
+        assert(md.secrets.length === 1);
+        assert(md.secrets[0].name === "secrets.someSecret");
+        assert(md.secrets[0].path === "atomist://some_secret");
+    });
+
+    it("should extract metadata from command handler with direct nested parameters and irrelevant fields", () => {
+        const h = new AddAtomistSpringAgentWithComposedParametersDirectlyOnHandlerAndIrrelevantFields();
+        const md = metadataFromInstance(h) as CommandHandlerMetadata;
+        assert(md.parameters.length === 1);
+        assert(md.parameters[0].name === "params.slackTeam");
+        assert(md.mapped_parameters.length === 2);
+        assert(md.mapped_parameters[0].local_key === "params.githubWebUrl");
+        assert(md.mapped_parameters[0].foreign_key === "atomist://github_url");
+        assert(md.secrets.length === 1);
+        assert(md.secrets[0].name === "secrets.someSecret");
+        assert(md.secrets[0].path === "atomist://some_secret");
+    });
+
+    it("should extract metadata from command handler with direct nested parameters and additional simple parameter", () => {
+        const h = new AddAtomistSpringAgentWithComposedParametersDirectlyOnHandlerAndStringParam();
+        const md = metadataFromInstance(h) as CommandHandlerMetadata;
+        assert(md.parameters.length === 2);
+        assert(md.parameters[0].name === "foo");
+        assert(md.parameters[1].name === "params.slackTeam");
+        assert(md.mapped_parameters.length === 2);
+        assert(md.mapped_parameters[0].local_key === "params.githubWebUrl");
+        assert(md.mapped_parameters[0].foreign_key === "atomist://github_url");
+        assert(md.secrets.length === 1);
+        assert(md.secrets[0].name === "secrets.someSecret");
+        assert(md.secrets[0].path === "atomist://some_secret");
+    });
+
+    it("should extract metadata from command handler with direct composed parameters", () => {
+        const h = new AddAtomistSpringAgentWithComposedExternalParameters();
+        const md = metadataFromInstance(h) as CommandHandlerMetadata;
+        assert(md.parameters.length === 2);
+        assert(md.parameters[0].name === "foo");
+        assert(md.parameters[1].name === "args.params.slackTeam");
+        assert(md.mapped_parameters.length === 2);
+        assert(md.mapped_parameters[0].local_key === "args.params.githubWebUrl");
+        assert(md.mapped_parameters[0].foreign_key === "atomist://github_url");
+        assert(md.secrets.length === 1);
+        assert(md.secrets[0].name === "args.secrets.someSecret");
+        assert(md.secrets[0].path === "atomist://some_secret");
+    });
+
+    it("should extract metadata from command handler with inherited and composed parameters", () => {
+        const h = new AddAtomistSpringAgentWithInheritedAndComposedParameters();
+        const md = metadataFromInstance(h) as CommandHandlerMetadata;
+        assert(md.parameters.length === 2);
+        assert(md.parameters[0].name === "foo");
+        assert(md.parameters[1].name === "args.slackTeam");
+        assert(md.mapped_parameters.length === 2);
+        assert(md.mapped_parameters[0].local_key === "args.githubWebUrl");
+        assert(md.mapped_parameters[0].foreign_key === "atomist://github_url");
+        assert(md.secrets.length === 1);
+        assert(md.secrets[0].name === "args.someSecret");
         assert(md.secrets[0].path === "atomist://some_secret");
     });
 
@@ -124,6 +193,117 @@ class AddAtomistSpringAgentWithComposedParameters implements HandleCommand<Compo
         assert(params.params.slackTeam);
         assert(params.params.repo !== undefined,
             `this.repo=[${params.params.repo}],this.slackTeam=[${params.params.slackTeam}],this.githubWebUrl=[${params.params.githubWebUrl}]`);
+        return Promise.resolve({code: 0});
+    }
+}
+
+@CommandHandler("add the Atomist Spring Boot agent to a Spring Boot project")
+@Tags("atomist", "spring")
+class AddAtomistSpringAgentWithComposedParametersDirectlyOnHandler implements HandleCommand {
+
+    public params = new AddAtomistSpringAgentParamsPart();
+
+    public secrets = new AddAtomistSpringAgentSecretsPart();
+
+    public handle(context: HandlerContext, params: this) {
+        console.log(`Invocation with team [${params.params.slackTeam}]`);
+        assert(params.secrets.someSecret);
+        assert(params.params.slackTeam);
+        assert(params.params.repo !== undefined,
+            `this.repo=[${params.params.repo}],this.slackTeam=[${params.params.slackTeam}],this.githubWebUrl=[${params.params.githubWebUrl}]`);
+        return Promise.resolve({code: 0});
+    }
+}
+
+@CommandHandler("add the Atomist Spring Boot agent to a Spring Boot project")
+@Tags("atomist", "spring")
+class AddAtomistSpringAgentWithComposedParametersDirectlyOnHandlerAndIrrelevantFields implements HandleCommand {
+
+    public params = new AddAtomistSpringAgentParamsPart();
+
+    public secrets = new AddAtomistSpringAgentSecretsPart();
+
+    public irrelevantObject = new GitHubRepoRef("a", "b");
+
+    public irrevelantString = "ignore me";
+
+    public handle(context: HandlerContext, params: this) {
+        console.log(`Invocation with team [${params.params.slackTeam}]`);
+        assert(params.secrets.someSecret);
+        assert(params.params.slackTeam);
+        assert(params.params.repo !== undefined,
+            `this.repo=[${params.params.repo}],this.slackTeam=[${params.params.slackTeam}],this.githubWebUrl=[${params.params.githubWebUrl}]`);
+        return Promise.resolve({code: 0});
+    }
+}
+
+@CommandHandler("add the Atomist Spring Boot agent to a Spring Boot project")
+@Tags("atomist", "spring")
+class AddAtomistSpringAgentWithComposedParametersDirectlyOnHandlerAndStringParam implements HandleCommand {
+
+    public params = new AddAtomistSpringAgentParamsPart();
+
+    public secrets = new AddAtomistSpringAgentSecretsPart();
+
+    @Parameter()
+    public foo: string;
+
+    public handle(context: HandlerContext, params: this) {
+        console.log(`Invocation with team [${params.params.slackTeam}]`);
+        assert(params.secrets.someSecret);
+        assert(params.params.slackTeam);
+        assert(params.params.repo !== undefined,
+            `this.repo=[${params.params.repo}],this.slackTeam=[${params.params.slackTeam}],this.githubWebUrl=[${params.params.githubWebUrl}]`);
+        return Promise.resolve({code: 0});
+    }
+}
+
+class ComposeAllAddAtomistSpringAgentParams {
+
+    public params = new AddAtomistSpringAgentParamsPart();
+
+    public secrets = new AddAtomistSpringAgentSecretsPart();
+
+}
+
+@CommandHandler("add the Atomist Spring Boot agent to a Spring Boot project")
+@Tags("atomist", "spring")
+class AddAtomistSpringAgentWithComposedExternalParameters implements HandleCommand {
+
+    public args = new ComposeAllAddAtomistSpringAgentParams();
+
+    @Parameter()
+    public foo: string;
+
+    public handle(context: HandlerContext, params: this) {
+        console.log(`Invocation with team [${params.args.params.slackTeam}]`);
+        assert(params.args.secrets.someSecret);
+        assert(params.args.params.slackTeam);
+        assert(params.args.params.repo !== undefined);
+        return Promise.resolve({code: 0});
+    }
+}
+
+class InheritedAndComposeParams extends AddAtomistSpringAgentParamsPart {
+
+    @Secret("atomist://some_secret")
+    public someSecret: string;
+}
+
+@CommandHandler("add the Atomist Spring Boot agent to a Spring Boot project")
+@Tags("atomist", "spring")
+class AddAtomistSpringAgentWithInheritedAndComposedParameters implements HandleCommand {
+
+    public args = new InheritedAndComposeParams();
+
+    @Parameter()
+    public foo: string;
+
+    public handle(context: HandlerContext, params: this) {
+        console.log(`Invocation with team [${params.args.slackTeam}]`);
+        assert(params.args.someSecret);
+        assert(params.args.slackTeam);
+        assert(params.args.repo !== undefined);
         return Promise.resolve({code: 0});
     }
 }

--- a/test/internal/metadata/classWithExternalParametersMetadataReadingTest.ts
+++ b/test/internal/metadata/classWithExternalParametersMetadataReadingTest.ts
@@ -1,0 +1,66 @@
+import "mocha";
+import { metadataFromInstance } from "../../../src/internal/metadata/metadataReading";
+
+import * as assert from "power-assert";
+import { CommandHandler, MappedParameter, Parameter, Secret, Tags } from "../../../src/decorators";
+import { HandleCommand } from "../../../src/HandleCommand";
+import { HandlerContext } from "../../../src/HandlerContext";
+import { MappedParameters } from "../../../src/index";
+import { CommandHandlerMetadata } from "../../../src/metadata/automationMetadata";
+
+describe("class with external parameters metadata reading", () => {
+
+    it("should extract metadata from command handler with external parameters", () => {
+        const h = new AddAtomistSpringAgentWithExternalParameters();
+        const md = metadataFromInstance(h) as CommandHandlerMetadata;
+        assert(md.parameters.length === 1);
+        assert(md.parameters[0].name === "slackTeam");
+        assert(md.mapped_parameters.length === 2);
+        assert(md.mapped_parameters[0].local_key === "githubWebUrl");
+        assert(md.mapped_parameters[0].foreign_key === "atomist://github_url");
+        assert(md.secrets.length === 1);
+        assert(md.secrets[0].name === "someSecret");
+        assert(md.secrets[0].path === "atomist://some_secret");
+    });
+
+});
+
+class AddAtomistSpringAgentParams {
+
+    @Parameter({
+        displayName: "Slack Team ID",
+        description: "team identifier for Slack team associated with this repo",
+        pattern: /^T[0-9A-Z]+$/,
+        validInput: "Slack team identifier of form T0123WXYZ",
+        required: true,
+    })
+    public slackTeam: string;
+
+    @MappedParameter("atomist://github_url")
+    public githubWebUrl: string;
+
+    @MappedParameter(MappedParameters.GitHubRepository)
+    public repo: string;
+
+    @Secret("atomist://some_secret")
+    public someSecret: string;
+
+}
+
+@CommandHandler("add the Atomist Spring Boot agent to a Spring Boot project")
+@Tags("atomist", "spring")
+class AddAtomistSpringAgentWithExternalParameters implements HandleCommand<AddAtomistSpringAgentParams> {
+
+    public freshParametersInstance() {
+        return new AddAtomistSpringAgentParams();
+    }
+
+    public handle(context: HandlerContext, params: AddAtomistSpringAgentParams) {
+        console.log(`Invocation with team [${params.slackTeam}]`);
+        assert(params.someSecret);
+        assert(params.slackTeam);
+        assert(params.repo !== undefined,
+            `this.repo=[${params.repo}],this.slackTeam=[${params.slackTeam}],this.githubWebUrl=[${params.githubWebUrl}]`);
+        return Promise.resolve({code: 0});
+    }
+}

--- a/test/internal/metadata/classWithExternalParametersMetadataReadingTest.ts
+++ b/test/internal/metadata/classWithExternalParametersMetadataReadingTest.ts
@@ -23,6 +23,19 @@ describe("class with external parameters metadata reading", () => {
         assert(md.secrets[0].path === "atomist://some_secret");
     });
 
+    it("should extract metadata from command handler with external parameters", () => {
+        const h = new AddAtomistSpringAgentWithComposedParameters();
+        const md = metadataFromInstance(h) as CommandHandlerMetadata;
+        assert(md.parameters.length === 1);
+        assert(md.parameters[0].name === "params.slackTeam");
+        assert(md.mapped_parameters.length === 2);
+        assert(md.mapped_parameters[0].local_key === "params.githubWebUrl");
+        assert(md.mapped_parameters[0].foreign_key === "atomist://github_url");
+        assert(md.secrets.length === 1);
+        assert(md.secrets[0].name === "secrets.someSecret");
+        assert(md.secrets[0].path === "atomist://some_secret");
+    });
+
 });
 
 class AddAtomistSpringAgentParams {
@@ -61,6 +74,56 @@ class AddAtomistSpringAgentWithExternalParameters implements HandleCommand<AddAt
         assert(params.slackTeam);
         assert(params.repo !== undefined,
             `this.repo=[${params.repo}],this.slackTeam=[${params.slackTeam}],this.githubWebUrl=[${params.githubWebUrl}]`);
+        return Promise.resolve({code: 0});
+    }
+}
+
+class AddAtomistSpringAgentParamsPart {
+
+    @Parameter({
+        displayName: "Slack Team ID",
+        description: "team identifier for Slack team associated with this repo",
+        pattern: /^T[0-9A-Z]+$/,
+        validInput: "Slack team identifier of form T0123WXYZ",
+        required: true,
+    })
+    public slackTeam: string;
+
+    @MappedParameter("atomist://github_url")
+    public githubWebUrl: string;
+
+    @MappedParameter(MappedParameters.GitHubRepository)
+    public repo: string;
+}
+
+class AddAtomistSpringAgentSecretsPart {
+
+    @Secret("atomist://some_secret")
+    public someSecret: string;
+}
+
+class ComposedAddAtomistSpringAgentParameters {
+
+    public params = new AddAtomistSpringAgentParamsPart();
+
+    public secrets = new AddAtomistSpringAgentSecretsPart();
+
+}
+
+@CommandHandler("add the Atomist Spring Boot agent to a Spring Boot project")
+@Tags("atomist", "spring")
+class AddAtomistSpringAgentWithComposedParameters implements HandleCommand<ComposedAddAtomistSpringAgentParameters> {
+
+    public freshParametersInstance() {
+        return new ComposedAddAtomistSpringAgentParameters();
+    }
+
+    public handle(context: HandlerContext, params: ComposedAddAtomistSpringAgentParameters) {
+        console.log(`Invocation with team [${params.params.slackTeam}]`);
+        assert(params.secrets.someSecret);
+        assert(params.params.slackTeam);
+        assert(params.params.repo !== undefined,
+            `this.repo=[${params.params.repo}],this.slackTeam=[${params.params.slackTeam}],this.githubWebUrl=[${params.params.githubWebUrl}]`);
         return Promise.resolve({code: 0});
     }
 }


### PR DESCRIPTION
Makes it easier to reuse parameters via composition rather than getting into inheritance hell.

- Adds nested parameter supports to all command handlers. Handles parameters, mapped parameters and secrets
- Change `generate` utility method to take a `RepoId` explicitly for flexibility and clarity. Backward compatible.
- Introduces new convenience parameter classes for generators