### PR TITLE
Notice the branch passed in

### DIFF
--- a/src/project/git/GitCommandGitProject.ts
+++ b/src/project/git/GitCommandGitProject.ts
@@ -102,6 +102,7 @@ export class GitCommandGitProject extends NodeFsLocalProject implements GitProje
                         private credentials: ProjectOperationCredentials, release: ReleaseFunction,
                         public provenance?: string) {
         super(id, baseDir, release);
+        this.branch = id.sha;
         logger.debug(`Created GitProject with token '${hideString(this.credentials.token)}'`);
     }
 

--- a/test/project/git/GitProjectTest.ts
+++ b/test/project/git/GitProjectTest.ts
@@ -79,6 +79,13 @@ describe("GitProject", () => {
             });
     }
 
+    it("knows about the branch passed by the repo ref", () => {
+        const p = tempProject(new GitHubRepoRef("owneryo", "repoyo", "branchyo"));
+        const gp = GitCommandGitProject.fromProject(p, Creds);
+
+        assert(gp.branch === "branchyo", `Branch was <${gp.branch}>`);
+    });
+
     it("add a file, init and commit", done => {
         const p = tempProject();
         p.addFileSync("Thing", "1");


### PR DESCRIPTION
This will fix docker-samples' failure to push. The branch field was only getting defined on init (new repo) or create branch; docker-samples calls push() for an existing branch.

Whether storing branch in this way, separately from the RepoRef, is another question, but at least this makes it work consistently.