### PR TITLE
Fix exec command, use name=value parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 -   Bug where a `SimpleProjectEditor` that did not return an `EditResult` and made
     no changes would fail due to unsuccessful git commit
+-   Add missing team ID to BuildableAutomationServer GraphQL endpoint
 
 ## [0.3.3][] - 2017-11-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
     editor didn't keep track of whether it made changes. This is the norm for simple functions
     taking `Project`.
 -   Moved `@types/graphql` to dependencies since its types are exported
+-   Command parameters now provided as PARAM=VALUE on `exec` command line
 
 ### Fixed
 

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -1,39 +1,51 @@
+import * as appRoot from "app-root-path";
 import * as child_process from "child_process";
 import * as fs from "fs";
+import * as stringify from "json-stringify-safe";
 import * as p from "path";
-import { CommandInvocation } from "../internal/invoker/Payload";
+import { Arg, CommandInvocation } from "../internal/invoker/Payload";
 import { logger } from "../internal/util/logger";
 import { cliAtomistConfig } from "./config";
 import { cliGitInfo } from "./gitInfo";
+
+/**
+ * Parse positional parameters into parameter name/value pairs.  The
+ * positional parameters should be of the form NAME[=VALUE].  If
+ * =VALUE is omitted, the value is set to `undefined`.  If the VALUE
+ * is empty, i.e., NAME=, then the value is the empty string.
+ *
+ * @param args typically argv._ from tags
+ * @return array of CommandInvocation Arg
+ */
+export function extractArgs(args: string[]): Arg[] {
+    return args.map(arg => {
+        const split = arg.indexOf("=");
+        if (split < 0) {
+            return { name: arg, value: undefined };
+        }
+        const name = arg.slice(0, split);
+        const value = arg.slice(split + 1);
+        return { name, value };
+    });
+}
+
+export function readVersion(): string {
+    try {
+        const pj = require(`${appRoot}/package.json`);
+        return `${pj.name} ${pj.version}`;
+    } catch (e) {
+        return "@atomist/automation-client 0.0.0";
+    }
+}
 
 export function start(
     path: string,
     runInstall: boolean = true,
     runCompile: boolean = true,
-) {
-    const ap = resolve(path);
-    path = `${ap}/node_modules/@atomist/automation-client/start.client.js`;
+): number {
 
-    if (!fs.existsSync(p.join(ap, "node_modules")) && runInstall) {
-        install(ap);
-    }
-
-    if (!fs.existsSync(path)) {
-        logger.error(`Project at '${ap}' is not a valid automation client project`);
-        process.exit(1);
-    }
-
-    if (runCompile) {
-        compile(ap);
-    }
-
-    logger.info(`Starting Automation Client in '${ap}'\n`);
-    try {
-        child_process.execSync(`node $ATOMIST_NODE_OPTIONS ${path}`,
-            { cwd: ap, stdio: "inherit", env: process.env });
-    } catch (e) {
-        process.exit(e.status);
-    }
+    const msg = "Starting Automation Client";
+    return execNode("start.client.js", "", msg, path, runInstall, runCompile);
 }
 
 export function run(
@@ -41,31 +53,11 @@ export function run(
     ci: CommandInvocation,
     runInstall: boolean = true,
     runCompile: boolean = true,
-) {
-    const ap = resolve(path);
-    path = `${ap}/node_modules/@atomist/automation-client/cli/run.js`;
+): number {
 
-    if (!fs.existsSync(p.join(ap, "node_modules")) && runInstall) {
-        install(ap);
-    }
-
-    if (!fs.existsSync(path)) {
-        logger.error(`Project at '${ap}' is not a valid automation client project`);
-        process.exit(1);
-    }
-
-    if (runCompile) {
-        compile(ap);
-    }
-
-    logger.info(`Running command '${ci.name}' in '${ap}'\n`);
-    try {
-        child_process.execSync(`node $ATOMIST_NODE_OPTIONS ${path} --request='${JSON.stringify(ci)}'`,
-            { cwd: ap, stdio: "inherit", env: process.env });
-        process.exit(0);
-    } catch (e) {
-        process.exit(e.status);
-    }
+    const args = `--request='${stringify(ci)}'`;
+    const msg = `Running command '${ci.name}'`;
+    return execNode("cli/run.js", args, msg, path, runInstall, runCompile);
 }
 
 export function config(argv: any): Promise<number> {
@@ -76,33 +68,84 @@ export function gitInfo(argv: any): Promise<number> {
     return cliGitInfo(argv["change-dir"]);
 }
 
-export function install(path: string) {
+function execNode(
+    cmd: string,
+    args: string,
+    message: string,
+    path: string,
+    runInstall: boolean,
+    runCompile: boolean,
+): number {
+    const ap = resolve(path);
+    path = `${ap}/node_modules/@atomist/automation-client/${cmd}`;
+
+    if (!fs.existsSync(p.join(ap, "node_modules")) && runInstall) {
+        const installStatus = install(ap);
+        if (installStatus !== 0) {
+            return installStatus;
+        }
+    }
+
+    if (!fs.existsSync(path)) {
+        logger.error(`Project at '${ap}' is not a valid automation client project`);
+        return 1;
+    }
+
+    if (runCompile) {
+        const compileStatus = compile(ap);
+        if (compileStatus !== 0) {
+            return compileStatus;
+        }
+    }
+
+    logger.info(`${message} in '${ap}'`);
+    try {
+        child_process.execSync(`node $ATOMIST_NODE_OPTIONS '${path}' ${args}`,
+            { cwd: ap, stdio: "inherit", env: process.env });
+    } catch (e) {
+        console.error(`Node command ${cmd} failed`);
+        return e.status as number;
+    }
+    return 0;
+}
+
+export function install(path: string): number {
     logger.info(`Running 'npm install' in '${path}'`);
     try {
-        checkPackageJson(path);
+        if (!checkPackageJson(path)) {
+            return 1;
+        }
         child_process.execSync(`npm install`,
             { cwd: path, stdio: "inherit", env: process.env });
     } catch (e) {
-        process.exit(e.status);
+        logger.error(`Installation failed`);
+        return e.status as number;
     }
+    return 0;
 }
 
-export function compile(path: string) {
+export function compile(path: string): number {
     logger.info(`Running 'npm run compile' in '${path}'`);
     try {
-        checkPackageJson(path);
+        if (!checkPackageJson(path)) {
+            return 1;
+        }
         child_process.execSync(`npm run compile`,
             { cwd: path, stdio: "inherit", env: process.env });
     } catch (e) {
-        process.exit(e.status);
+        logger.error(`Compilation failed`);
+        return e.status as number;
     }
+    return 0;
 }
 
-export function checkPackageJson(path: string) {
-    if (!fs.existsSync(p.join(path, "package.json"))) {
-        logger.error(`No 'package.json' in '${path}'`);
-        process.exit(1);
+export function checkPackageJson(path: string): boolean {
+    const pkgPath = p.join(path, "package.json");
+    if (!fs.existsSync(pkgPath)) {
+        console.error(`No 'package.json' in '${path}'`);
+        return false;
     }
+    return true;
 }
 
 export function resolve(path: string): string {

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -61,7 +61,7 @@ function invokeOnConsole(automationServer: AutomationServer, ci: CommandInvocati
         secrets: ci.args ? ci.args.filter(a => handler.secrets.some(p => p.name === a.name))
             .map(a => {
                 const s = handler.secrets.find(p => p.name === a.name);
-                return { name: s.path, value: a.value};
+                return { name: s.path, value: a.value };
             }) : undefined,
     };
 
@@ -82,7 +82,7 @@ function invokeOnConsole(automationServer: AutomationServer, ci: CommandInvocati
                 process.exit(1);
             });
     } catch (e) {
-        console.log("Error: Command failed: %s", e.message);
-        process.exit(1);
+        console.log("Unhandled Error: Command failed: %s", e.message);
+        process.exit(11);
     }
 }

--- a/src/server/BuildableAutomationServer.ts
+++ b/src/server/BuildableAutomationServer.ts
@@ -63,11 +63,24 @@ export class BuildableAutomationServer extends AbstractAutomationServer {
                 private fallbackSecretResolver: SecretResolver = new NodeConfigSecretResolver()) {
         super();
         if (opts.endpoints && opts.endpoints.graphql) {
-            if (opts.token) {
-                this.graphClient = new ApolloGraphClient(opts.endpoints.graphql,
-                    {Authorization: `token ${opts.token}`});
-            } else {
-                logger.warn("Cannot create graph client due to missing token");
+            if (opts.teamIds) {
+                let teamId: string;
+                if (opts.teamIds.length === 1) {
+                    teamId = opts.teamIds[0];
+                } else if (opts.teamIds.length > 1) {
+                    teamId = opts.teamIds[0];
+                    logger.warn(`Provided ${opts.teamIds.length} team IDs, using the first: ${teamId}`);
+                }
+                if (teamId) {
+                    if (opts.token) {
+                        this.graphClient = new ApolloGraphClient(`${opts.endpoints.graphql}/${teamId}`,
+                            { Authorization: `token ${opts.token}` });
+                    } else {
+                        logger.warn("Cannot create graph client due to missing token");
+                    }
+                } else {
+                    logger.warn("Cannot create graph client because no team IDs provided");
+                }
             }
         } else {
             logger.warn("Cannot create graph client due to missing GraphQL URL");

--- a/test-api/credentials.ts
+++ b/test-api/credentials.ts
@@ -1,3 +1,6 @@
+import { LoggingConfig } from "../src/internal/util/logger";
+LoggingConfig.format = "cli";
+
 function barf(): string {
     throw new Error("<please set GITHUB_TOKEN env variable>");
 }

--- a/test/cli/commandsTest.ts
+++ b/test/cli/commandsTest.ts
@@ -1,0 +1,62 @@
+import "mocha";
+import * as assert from "power-assert";
+
+import { extractArgs } from "../../src/cli/commands";
+
+describe("atomist CLI", () => {
+
+    describe("extractArgs", () => {
+
+        it("should parse parameter value pairs", () => {
+            const pvs = ["mavis=staples", "cleotha=staples", "pervis=staples", "roebuck=pops"];
+            const args = extractArgs(pvs);
+            assert(args.length === pvs.length);
+            assert(args[0].name === "mavis");
+            assert(args[0].value === "staples");
+            assert(args[1].name === "cleotha");
+            assert(args[1].value === "staples");
+            assert(args[2].name === "pervis");
+            assert(args[2].value === "staples");
+            assert(args[3].name === "roebuck");
+            assert(args[3].value === "pops");
+        });
+
+        it("should parse values with equal signs", () => {
+            const pvs = ["staples=cleotha=mavis=pervis=pops"];
+            const args = extractArgs(pvs);
+            assert(args.length === pvs.length);
+            assert(args[0].name === "staples");
+            assert(args[0].value === "cleotha=mavis=pervis=pops");
+        });
+
+        it("should parse parameters without value to undefined", () => {
+            const pvs = ["cleotha", "mavis", "pervis", "pops"];
+            const args = extractArgs(pvs);
+            assert(args.length === pvs.length);
+            assert(args[0].name === "cleotha");
+            assert(args[0].value === undefined);
+            assert(args[1].name === "mavis");
+            assert(args[1].value === undefined);
+            assert(args[2].name === "pervis");
+            assert(args[2].value === undefined);
+            assert(args[3].name === "pops");
+            assert(args[3].value === undefined);
+        });
+
+        it("should parse parameters with empty values to empty strings", () => {
+            const pvs = ["cleotha=", "mavis=", "pervis=", "pops="];
+            const args = extractArgs(pvs);
+            assert(args.length === pvs.length);
+            assert(args[0].name === "cleotha");
+            assert(args[0].value === "");
+            assert(args[1].name === "mavis");
+            assert(args[1].value === "");
+            assert(args[2].name === "pervis");
+            assert(args[2].value === "");
+            assert(args[3].name === "pops");
+            assert(args[3].value === "");
+        });
+
+    });
+
+});


### PR DESCRIPTION
Using yargs strict likely broke passing parameters to handlers via the
exec CLI command.  This fixes that, also changing parameter
specification to just NAME=VALUE rather than --NAME=VALUE.

Refactor the exec and start commands to share more code and rely less
on exceptions.  Add some tests.

Towards #55