### PR TITLE
Fix error in attempting to commit with git project isn't dirty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+-   **Breaking** `successfulEdit` function `edited` argument is now required instead of defaulting
+    to true
+-   `EditResult.edited` is now optional. An undefined value is valid and means that the
+    editor didn't keep track of whether it made changes. This is the norm for simple functions
+    taking `Project`.
 -   Moved `@types/graphql` to dependencies since its types are exported
+
+### Fixed
+
+-   Bug where a `SimpleProjectEditor` that did not return an `EditResult` and made
+    no changes would fail due to unsuccessful git commit
 
 ## [0.3.3][] - 2017-11-20
 

--- a/src/operations/edit/projectEditor.ts
+++ b/src/operations/edit/projectEditor.ts
@@ -22,9 +22,10 @@ export type AnyProjectEditor<P = undefined> = ProjectEditor<P> | SimpleProjectEd
 export interface EditResult<P extends Project = Project> extends ActionResult<P> {
 
     /**
-     * Whether or not this project was edited
+     * Whether or not this project was edited.
+     * Undefined if we don't know, as not all editors keep track of their doings.
      */
-    readonly edited: boolean;
+    readonly edited?: boolean;
 }
 
 export function toEditor<P = undefined>(ed: (SimpleProjectEditor<P> | ProjectEditor<P>)): ProjectEditor<P> {
@@ -33,12 +34,12 @@ export function toEditor<P = undefined>(ed: (SimpleProjectEditor<P> | ProjectEdi
             .then(r =>
                 // See what it returns
                 isProject(r) ?
-                    successfulEdit(r) :
+                    successfulEdit(r, undefined) :
                     r as EditResult)
             .catch(err => failedEdit(proj, err));
 }
 
-export function successfulEdit<P extends Project>(p: P, edited: boolean = true): EditResult<P> {
+export function successfulEdit<P extends Project>(p: P, edited: boolean): EditResult<P> {
     return {
         target: p,
         success: true,
@@ -56,5 +57,5 @@ export function failedEdit<P extends Project>(p: P, error: Error, edited: boolea
 }
 
 export function flushAndSucceed<P extends Project>(p: P): Promise<EditResult<P>> {
-    return p.flush().then(successfulEdit);
+    return p.flush().then(pf => successfulEdit(pf, undefined));
 }

--- a/src/operations/edit/projectEditorOps.ts
+++ b/src/operations/edit/projectEditorOps.ts
@@ -9,7 +9,8 @@ import {
 function combineEditResults(r1: EditResult, r2: EditResult): EditResult {
     return {
         ...r1, ...r2,
-        edited: r1.edited || r2.edited,
+        edited: (r1.edited || r2.edited) ? true :
+            (r1.edited === false && r2.edited === false) ? false : undefined,
     };
 }
 

--- a/src/operations/support/editorUtils.ts
+++ b/src/operations/support/editorUtils.ts
@@ -1,4 +1,5 @@
 import { HandlerContext } from "../../HandlerContext";
+import { logger } from "../../internal/util/logger";
 import { GitProject } from "../../project/git/GitProject";
 import { Project } from "../../project/Project";
 import {
@@ -12,12 +13,17 @@ import {
 import { EditResult, ProjectEditor, successfulEdit } from "../edit/projectEditor";
 
 /**
- * Edit a GitHub project using a PR or branch
+ * Edit a GitHub project using a PR or branch.
+ * Do not attempt any git updates if (a) edited is explicitly set to false by the editor
+ * or (b) edited is undefined and git status is not dirty. If edited is explicitly
+ * set to true by the editor and the git status is not dirty, this is a developer error
+ * which should result in a runtime error.
  * @param context handler context for this operation
  * @param repo repo id
  * @param editor editor to use
  * @param ei how to persist the edit
  * @param parameters to editor
+ * @return EditResult instance that reports as to whether the project was actually edited
  */
 export function editRepo<P>(context: HandlerContext,
                             repo: Project,
@@ -43,13 +49,7 @@ export function editProjectUsingPullRequest<P>(context: HandlerContext,
                                                parameters?: P): Promise<EditResult> {
 
     return editor(gp, context, parameters)
-        .then(r => r.edited ?
-            raisePr(gp, pr) :
-            {
-                target: gp,
-                success: false,
-                edited: false,
-            });
+        .then(r => doWithEditResult(r as EditResult<GitProject>, () => raisePr(gp, pr)));
 }
 
 export function editProjectUsingBranch<P>(context: HandlerContext,
@@ -59,13 +59,35 @@ export function editProjectUsingBranch<P>(context: HandlerContext,
                                           parameters?: P): Promise<EditResult> {
 
     return editor(gp, context, parameters)
-        .then(r => r.edited ?
-            createAndPushBranch(gp, ci) :
-            {
-                target: gp,
-                success: false,
-                edited: false,
+        .then(r =>
+            // TODO fix this type cast
+            doWithEditResult(r as EditResult<GitProject>, () => createAndPushBranch(gp, ci)));
+}
+
+/**
+ * Perform git operation on the project only if edited != false or status is dirty
+ * @param {EditResult<GitProject>} r
+ * @param {() => Promise<EditResult>} gitop
+ * @return {Promise<EditResult>}
+ */
+function doWithEditResult(r: EditResult<GitProject>, gitop: () => Promise<EditResult>): Promise<EditResult> {
+    if (r.edited === true) {
+        // Do a second check to see if the project is dirty
+        return gitop();
+    }
+    if (r.edited === undefined) {
+        // Check git status
+        return r.target.gitStatus()
+            .then(status => {
+                return status.isClean ? ({
+                    target: r.target,
+                    success: true,
+                    edited: false,
+                }) : gitop();
             });
+    }
+    logger.info("NOT committing %j as it's not dirty, edited=%s", r.target.id, r.edited);
+    return Promise.resolve(r);
 }
 
 /**
@@ -89,6 +111,6 @@ export function raisePr(gp: GitProject, pr: PullRequest): Promise<EditResult> {
     return createAndPushBranch(gp, pr)
         .then(x => {
             return gp.raisePullRequest(pr.title, pr.body)
-                .then(r => successfulEdit(gp));
+                .then(r => successfulEdit(gp, true));
         });
 }

--- a/test/credentials.ts
+++ b/test/credentials.ts
@@ -1,8 +1,14 @@
+import { GitHubRepoRef } from "../src/operations/common/GitHubRepoRef";
+
 function barf(): string {
     throw new Error("<please set GITHUB_TOKEN env variable>");
 }
 
 export const GitHubToken: string = process.env.GITHUB_TOKEN || barf();
+
+export const Creds = { token: GitHubToken };
+
+export const RepoThatExists = new GitHubRepoRef("atomist-travisorg", "this-repository-exists");
 
 function visibility(): "public" | "private" {
     const vis = process.env.GITHUB_VISIBILITY || "private";

--- a/test/operations/edit/editAllTest.ts
+++ b/test/operations/edit/editAllTest.ts
@@ -17,7 +17,6 @@ import { Project } from "../../../src/project/Project";
 describe("editAll", () => {
 
     it("should edit with simple function", done => {
-
         const editor: SimpleProjectEditor = p => {
             p.addFileSync("thing", "1");
             return Promise.resolve(p);
@@ -44,7 +43,7 @@ describe("editAll", () => {
             fromListRepoLoader(projects))
             .then(edits => {
                 assert(edits.length === projects.length);
-                assert(!edits.some(e => !e.edited));
+                assert(!edits.some(e => e.edited !== undefined));
                 assert.deepEqual(projectsEdited, projects);
                 return edits[0].target.findFile("thing")
                     .then(f => f.getContent()

--- a/test/operations/edit/editOneTest.ts
+++ b/test/operations/edit/editOneTest.ts
@@ -38,7 +38,7 @@ describe("editOne", () => {
             repoRef, undefined,
             fromListRepoLoader(projects))
             .then(editResult => {
-                assert(editResult.edited);
+                assert(editResult.edited === undefined, "Simple editors don't know what they did. They are truly simple");
                 assert.deepEqual(projectsEdited, projects);
                 return editResult.target.findFile("thing")
                     .then(f => f.getContent()

--- a/test/operations/edit/projectEditorsOpsTest.ts
+++ b/test/operations/edit/projectEditorsOpsTest.ts
@@ -52,7 +52,7 @@ describe("editor chaining", () => {
         const editorChain = chainEditors(editor, NoOpEditor);
         editorChain(project, null)
             .then(r => {
-                assert(r.edited);
+                assert(r.edited === undefined);
                 assert(!!project.findFileSync("thing"));
                 done();
             }).catch(done);
@@ -111,7 +111,7 @@ describe("editor chaining", () => {
         const editorChain = chainEditors(projectFunction, NoOpEditor);
         editorChain(project, null)
             .then(r => {
-                assert(r.edited);
+                assert(r.edited === undefined);
                 done();
             }).catch(done);
     });
@@ -124,7 +124,7 @@ describe("editor chaining", () => {
         const editorChain = chainEditors(projectFunction, NoOpEditor, (p: Project) => Promise.resolve(p));
         editorChain(project, null)
             .then(r => {
-                assert(r.edited);
+                assert(r.edited === undefined);
                 done();
             }).catch(done);
     });

--- a/test/operations/support/editorUtilsTest.ts
+++ b/test/operations/support/editorUtilsTest.ts
@@ -1,0 +1,78 @@
+import "mocha";
+import * as assert from "power-assert";
+
+import { GitHubRepoRef } from "../../../src/operations/common/GitHubRepoRef";
+import { PullRequest } from "../../../src/operations/edit/editModes";
+import { toEditor } from "../../../src/operations/edit/projectEditor";
+import { editProjectUsingBranch, editProjectUsingPullRequest } from "../../../src/operations/support/editorUtils";
+import { GitCommandGitProject } from "../../../src/project/git/GitCommandGitProject";
+import { Creds, RepoThatExists } from "../../credentials";
+import { deleteRepoIfExists, newRepo } from "../../project/git/GitProjectTest";
+
+const NoOpEditor = toEditor(p => {
+    return Promise.resolve(p);
+});
+
+const EditorThatChangesProject = toEditor(p => p.addFile("thing", "thing"));
+
+describe("editorUtils", () => {
+
+    it("doesn't attempt to commit without changes", done => {
+        GitCommandGitProject.cloned(Creds, RepoThatExists)
+            .then(p => {
+                return editProjectUsingBranch(undefined, p, NoOpEditor,
+                    {branch: "dont-create-me-or-i-barf&&&####&&& we", message: "whocares"})
+                    .then(er => {
+                        console.log(p.baseDir);
+                        assert(!er.edited);
+                        done();
+                    });
+            }).catch(done);
+    }).timeout(15000);
+
+    it("creates branch with changes in simple editor", done => {
+        newRepo()
+            .then(repo => {
+                return GitCommandGitProject.cloned(Creds, new GitHubRepoRef(repo.owner, repo.repo))
+                    .then(p => {
+                        return editProjectUsingBranch(undefined, p, EditorThatChangesProject,
+                            new PullRequest("x", "y"))
+                            .then(er => {
+                                assert(er.edited);
+                            }).then(() => deleteRepoIfExists(repo));
+                    }).catch(err => deleteRepoIfExists(repo)
+                        .then(() => Promise.reject(err)));
+            }).then(() => done(), done);
+    }).timeout(15000);
+
+    it("doesn't attempt to create PR without changes", done => {
+        GitCommandGitProject.cloned(Creds, RepoThatExists)
+            .then(p => p.gitStatus().then(status => {
+                assert(status.isClean);
+                return p;
+            }))
+            .then(p => {
+                return editProjectUsingPullRequest(undefined, p, NoOpEditor,
+                    new PullRequest("x", "y"))
+                    .then(er => {
+                        assert(!er.edited);
+                    });
+            }).then(() => done(), done);
+    }).timeout(15000);
+
+    it("creates PR with changes in simple editor", done => {
+        newRepo()
+            .then(repo => {
+                return GitCommandGitProject.cloned(Creds, new GitHubRepoRef(repo.owner, repo.repo))
+                    .then(p => {
+                        return editProjectUsingPullRequest(undefined, p, EditorThatChangesProject,
+                            new PullRequest("x", "y"))
+                            .then(er => {
+                                assert(er.edited);
+                            }).then(() => deleteRepoIfExists(repo));
+                    }).catch(err => deleteRepoIfExists(repo)
+                        .then(() => Promise.reject(err)));
+            }).then(() => done(), done);
+    }).timeout(15000);
+
+});


### PR DESCRIPTION
Motivation was to fix an error in attempting to commit when git project isn't dirty. This turned into an overhaul of `EditResult.edited` which now has 3 possible values, depending on the editor:

- `false`: Editor says I didn't edit this or don't want you to persist any changes I made
- `true`: Editor says I did edit this, don't bother checking with git
- `undefined`: Editor says I have no idea what I did. Likely to result from wrapping a simple function returning `Promise<Project>`

Paired with @jessitron 