### PR TITLE
Fix nested mapped parameters and secrets handling

### DIFF
--- a/src/metadata/automationMetadata.ts
+++ b/src/metadata/automationMetadata.ts
@@ -99,12 +99,23 @@ export interface SecretDeclaration {
     path: string;
 }
 
-export interface EventHandlerMetadata extends AutomationMetadata {
+export interface SecretsMetadata {
+
+    secrets?: SecretDeclaration[];
+
+}
+
+export interface EventHandlerMetadata extends AutomationMetadata, SecretsMetadata {
 
     subscriptionName: string;
     subscription: string;
 
-    secrets?: SecretDeclaration[];
+}
+
+export interface ParameterMetadata extends SecretsMetadata {
+
+    parameters?: Parameter[];
+    mapped_parameters?: MappedParameterDeclaration[];
 }
 
 /**
@@ -112,11 +123,8 @@ export interface EventHandlerMetadata extends AutomationMetadata {
  * allowing invocation from both or by other methods such as command line
  * or REST
  */
-export interface CommandHandlerMetadata extends AutomationMetadata {
+export interface CommandHandlerMetadata extends AutomationMetadata, ParameterMetadata {
 
     intent?: string[];
-    parameters?: Parameter[];
 
-    mapped_parameters?: MappedParameterDeclaration[];
-    secrets?: SecretDeclaration[];
 }

--- a/src/operations/generate/generatorToCommand.ts
+++ b/src/operations/generate/generatorToCommand.ts
@@ -79,7 +79,7 @@ function handle<P extends BaseSeedDrivenGeneratorParameters>(ctx: HandlerContext
         .then(() => generate(
             startingPoint(params, ctx, details.repoLoader(params))
                 .then(p => {
-                    return ctx.messageClient.respond(`Cloned seed project from ${params.source.owner}/${params.source.repo}`)
+                    return ctx.messageClient.respond(`Cloned seed project from \`${params.source.owner}/${params.source.repo}\``)
                         .then(() => p);
                 }),
             ctx,

--- a/test/internal/invoker/functionStyleCommandHandlerTest.ts
+++ b/test/internal/invoker/functionStyleCommandHandlerTest.ts
@@ -20,8 +20,10 @@ describe("function style command handler invocation", () => {
 
         const payload: CommandInvocation = {
             name: "AddAtomistSpringAgent",
-            mappedParameters: [],
-            secrets : [],
+            mappedParameters: [ {name: "githubWebUrl", value: "the restaurant at the end of the universe"}],
+            secrets : [{
+                name: "atomist://some_secret", value: "Vogons write the best poetry",
+            }],
             args: [{
                 name: "slackTeam",
                 value: "T1066",

--- a/test/operations/edit/editorHandlerTest.ts
+++ b/test/operations/edit/editorHandlerTest.ts
@@ -53,7 +53,7 @@ describe("editorHandler", () => {
         s.invokeCommand({
             name: "editor",
             args: [{name: "slackTeam", value: "T1691"}],
-            secrets: [{name: "atomist://some_secret", value: "some_secret"}],
+            secrets: [{name: "github://user_token?scopes=repo,user", value: "antechinus"}],
         }, {
             teamId: "T666",
             correlationId: "555",


### PR DESCRIPTION
Nested parameters and secrets were not correctly handled. This fixes that and also refines metadata hierarchy to capture commonality between `EventHandlerMetadata` and `CommandHandlerMetadata`.

Paired with @jessitron 