### PR TITLE
Separate ignored changes from other changes

### DIFF
--- a/src/project/git/GitCommandGitProject.ts
+++ b/src/project/git/GitCommandGitProject.ts
@@ -101,6 +101,9 @@ export class GitCommandGitProject extends NodeFsLocalProject implements GitProje
         return this.runCommandInCurrentWorkingDirectory("git init");
     }
 
+    /**
+     * Deprecated; use gitStatus().then(status => status.isClean) instead
+     */
     public isClean(): Promise<CommandResult<this>> {
         return this.runCommandInCurrentWorkingDirectory("git status --porcelain")
             .then(commandResult => {

--- a/src/project/git/gitStatus.ts
+++ b/src/project/git/gitStatus.ts
@@ -50,7 +50,7 @@ function collectCleanliness(baseDir: string): Promise<{ isClean: boolean }> {
 
 function collectIgnoredChanges(baseDir: string): Promise<{
     ignoredChanges: string[],
-    raw: string
+    raw: string,
 }> {
     return runIn(baseDir, "git status --porcelain=v2 --ignored")
         .then(porcelainStatusResult => {

--- a/test/project/git/CachedGitCloneTest.ts
+++ b/test/project/git/CachedGitCloneTest.ts
@@ -9,6 +9,7 @@ import { CachingDirectoryManager } from "../../../src/spi/clone/CachingDirectory
 import { CloneOptions, DefaultCloneOptions } from "../../../src/spi/clone/DirectoryManager";
 import { TmpDirectoryManager } from "../../../src/spi/clone/tmpDirectoryManager";
 import { GitHubToken } from "../../atomist.config";
+import { isFullyClean } from "../../../src/project/git/gitStatus";
 
 const Creds = { token: GitHubToken };
 const Owner = "atomist-travisorg";
@@ -68,7 +69,7 @@ describe("cached git clone projects", () => {
                         .then(status => {
                             assert(clone2.baseDir === clone1.baseDir,
                                 "this test is pointless if not in the same spot");
-                            assert(status.isClean, status.raw);
+                            assert(isFullyClean(status), status.raw);
                             return clone2.release();
                         })))
             .then(done, done);
@@ -80,7 +81,7 @@ describe("cached git clone projects", () => {
             .then(clone1 =>
                 clone1.gitStatus().then(status1 => {
                     assert(status1.branch === "some-branch", "branch is " + status1.branch);
-                    assert(status1.isClean);
+                    assert(isFullyClean(status1));
                     return clone1.release()
                         .then(() => getAClone({ repoName }))
                         .then(clone2 =>
@@ -89,7 +90,7 @@ describe("cached git clone projects", () => {
                                     assert(clone2.baseDir === clone1.baseDir,
                                         "this test is pointless if not in the same spot");
                                     assert(status.branch, "master"); // TODO: this needs to be the default branch
-                                    assert(status.isClean, status.raw);
+                                    assert(isFullyClean(status), status.raw);
                                     return clone2.release();
                                 }));
                 }))
@@ -102,7 +103,7 @@ describe("cached git clone projects", () => {
             .then(clone1 =>
                 clone1.gitStatus().then(status1 => {
                     assert(status1.branch === "this-directory-exists", "branch is " + status1.branch);
-                    assert(status1.isClean);
+                    assert(isFullyClean(status1));
                     return clone1.release()
                         .then(() => getAClone({ repoName }))
                         .then(clone2 =>
@@ -111,7 +112,7 @@ describe("cached git clone projects", () => {
                                     assert(clone2.baseDir === clone1.baseDir,
                                         "this test is pointless if not in the same spot");
                                     assert(status.branch, "master"); // TODO: this needs to be the default branch
-                                    assert(status.isClean, status.raw);
+                                    assert(isFullyClean(status), status.raw);
                                     return clone2.release();
                                 }));
                 }))

--- a/test/project/git/CachedGitCloneTest.ts
+++ b/test/project/git/CachedGitCloneTest.ts
@@ -5,11 +5,11 @@ import { runCommand } from "../../../src/action/cli/commandLine";
 import { GitHubRepoRef } from "../../../src/operations/common/GitHubRepoRef";
 import { GitCommandGitProject } from "../../../src/project/git/GitCommandGitProject";
 import { GitProject } from "../../../src/project/git/GitProject";
+import { isFullyClean } from "../../../src/project/git/gitStatus";
 import { CachingDirectoryManager } from "../../../src/spi/clone/CachingDirectoryManager";
 import { CloneOptions, DefaultCloneOptions } from "../../../src/spi/clone/DirectoryManager";
 import { TmpDirectoryManager } from "../../../src/spi/clone/tmpDirectoryManager";
 import { GitHubToken } from "../../atomist.config";
-import { isFullyClean } from "../../../src/project/git/gitStatus";
 
 const Creds = { token: GitHubToken };
 const Owner = "atomist-travisorg";

--- a/test/project/git/GitStatusTest.ts
+++ b/test/project/git/GitStatusTest.ts
@@ -1,13 +1,13 @@
 import "mocha";
 
+import stringify = require("json-stringify-safe");
 import * as assert from "power-assert";
 import { GitHubRepoRef } from "../../../src/operations/common/GitHubRepoRef";
 import { GitCommandGitProject } from "../../../src/project/git/GitCommandGitProject";
 import { GitProject } from "../../../src/project/git/GitProject";
+import { isFullyClean } from "../../../src/project/git/gitStatus";
 import { TmpDirectoryManager } from "../../../src/spi/clone/tmpDirectoryManager";
 import { GitHubToken } from "../../atomist.config";
-import stringify = require("json-stringify-safe");
-import { isFullyClean } from "../../../src/project/git/gitStatus";
 
 const TargetOwner = "atomist-travisorg";
 const ExistingRepo = "this-repository-exists";
@@ -42,7 +42,7 @@ describe("git status analysis", () => {
                 project.gitStatus())
             .then(status => {
                 assert(!status.isClean);
-                assert(status.ignoredChanges.length === 0)
+                assert(status.ignoredChanges.length === 0);
             })
             .then(done, done);
     }).timeout(5000);
@@ -56,7 +56,7 @@ describe("git status analysis", () => {
             .then(status => {
                 assert(status.isClean);
                 assert(status.raw === "! ignored-file\n", status.raw);
-                assert.deepEqual(status.ignoredChanges,["ignored-file"], stringify(status.ignoredChanges))
+                assert.deepEqual(status.ignoredChanges, ["ignored-file"], stringify(status.ignoredChanges));
             })
             .then(done, done);
     }).timeout(5000);


### PR DESCRIPTION
because usually when we ask whether a project is clean we mean, is there something to commit?
I was getting push errors in linting because the only change was in node_modules

this makes status.isClean ignore ignored files, while still storing the ignored file changes, so that my tests can check for whether it's _really_ clean. (also includes the raw output, would have helped with debugging this one)

This is consistent with GitProject.isClean(), which shall now be deprecated.