### PR TITLE
Remove RemoveSeedFiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 [Unreleased]: https://github.com/atomist/automation-client-ts/compare/0.4.0...HEAD
 
+### Changed
+
+-   The `AllFiles` glob pattern was simplified to `**`
+
+### Fixed
+
+-   Issues with deleting files and directories in an InMemoryProject
+
+### Removed
+
+-   RemoveSeedFiles as it was not generic nor provided much convenience
+
 ## [0.4.0][] - 2017-11-28
 
 [0.4.0]: https://github.com/atomist/automation-client-ts/compare/0.3.5...0.4.0

--- a/src/operations/common/params/SourceRepoParameters.ts
+++ b/src/operations/common/params/SourceRepoParameters.ts
@@ -1,4 +1,3 @@
-
 import { Parameter } from "../../../decorators";
 import { RepoRef } from "../RepoId";
 import { GitBranchRegExp, GitHubNameRegExp } from "./gitHubPatterns";

--- a/src/operations/generate/UniversalSeed.ts
+++ b/src/operations/generate/UniversalSeed.ts
@@ -44,7 +44,7 @@ export class UniversalSeed extends SeedDrivenGenerator {
     }
 
     public projectEditor(ctx: HandlerContext, params: this): ProjectEditor {
-        return chainEditors(RemoveSeedFiles, curry(cleanReadMe)(this.description));
+        return chainEditors(curry(cleanReadMe)(this.description));
     }
 }
 
@@ -58,22 +58,7 @@ export function cleanReadMe(description: string, project: Project): Promise<Proj
     return doWithFiles(project, "README.md", readMe => {
         readMe.recordReplace(/^#[\\s\\S]*?## Development/, `# ${project.name}
 This project contains ${description}.
+
 ## Development`);
     });
 }
-
-export const RemoveSeedFiles: ProjectEditor = project => {
-    const filesToDelete: string[] = [
-        ".travis.yml",
-        "LICENSE",
-        "CHANGELOG.md",
-        "CODE_OF_CONDUCT.md",
-        "CONTRIBUTING.md",
-    ];
-    defer(project, deleteFiles(project, "/*", f => filesToDelete.includes(f.path)));
-    const deleteDirs: string[] = [
-        ".travis",
-    ];
-    deleteDirs.forEach(d => defer(project, project.deleteDirectory(d)));
-    return flushAndSucceed(project);
-};

--- a/src/project/fileGlobs.ts
+++ b/src/project/fileGlobs.ts
@@ -2,7 +2,7 @@
  * Glob pattern to match all files in a project. Standard glob syntax
  * @type {string}
  */
-export const AllFiles = "**/**";
+export const AllFiles = "**";
 
 /**
  * Negative glob to exclude .git directory
@@ -24,10 +24,10 @@ export const ExcludeTarget = "!target/**";
  * Must be combined with a positive glob.
  * @type {[string , string]}
  */
-export const DefaultExcludes = [ ExcludeGit, ExcludeNodeModules, ExcludeTarget ];
+export const DefaultExcludes = [ExcludeGit, ExcludeNodeModules, ExcludeTarget];
 
 /**
  * Include all files except with default exclusions (git and node modules)
  * @type {[string , string , string]}
  */
-export const DefaultFiles = [ AllFiles ].concat(DefaultExcludes);
+export const DefaultFiles = [AllFiles].concat(DefaultExcludes);

--- a/src/project/mem/InMemoryProject.ts
+++ b/src/project/mem/InMemoryProject.ts
@@ -94,11 +94,11 @@ export class InMemoryProject extends AbstractProject {
     }
 
     public deleteDirectorySync(path: string): void {
-        for (const f of this.memFiles) {
-            if (f.path.startsWith(path)) {
-                this.recordDeleteFile(path);
+        this.memFiles.forEach(f => {
+            if (f.path.startsWith(`${path}/`)) {
+                this.deleteFileSync(f.path);
             }
-        }
+        });
     }
 
     public deleteDirectory(path: string): Promise<this> {
@@ -121,7 +121,7 @@ export class InMemoryProject extends AbstractProject {
     }
 
     public directoryExistsSync(path: string): boolean {
-        return this.memFiles.some(f => f.path.startsWith(path));
+        return this.memFiles.some(f => f.path.startsWith(`${path}/`));
     }
 
     public fileExistsSync(path: string): boolean {
@@ -136,7 +136,7 @@ export class InMemoryProject extends AbstractProject {
         const matchingPaths =
             minimatch.match(this.memFiles.map(f => f.path), globPatterns[0]);
         this.memFiles.map(f => matchingPaths.includes(f.path));
-        return spigot.array({objectMode: true},
+        return spigot.array({ objectMode: true },
             this.memFiles.filter(f => matchingPaths.some(mp => mp === f.path)),
         );
     }

--- a/test/project/mem/InMemoryProjectTest.ts
+++ b/test/project/mem/InMemoryProjectTest.ts
@@ -9,32 +9,32 @@ import { toPromise } from "../../../src/project/util/projectUtils";
 describe("InMemoryProject", () => {
 
     it("findFileSync: existing file", () => {
-        const thisProject = InMemoryProject.of({path: "package.json", content: "{ node: true }"});
+        const thisProject = InMemoryProject.of({ path: "package.json", content: "{ node: true }" });
         const f = thisProject.findFileSync("package.json");
         assert(f.getContentSync());
         assert(f.getContentSync().indexOf("node") !== -1);
     });
 
     it("findFileSync: no such file", () => {
-        const thisProject = InMemoryProject.of({path: "package.json", content: "{ node: true }"});
+        const thisProject = InMemoryProject.of({ path: "package.json", content: "{ node: true }" });
         const f = thisProject.findFileSync("xxxxpackage.json");
         assert(f === undefined);
     });
 
     it("fileExistsSync: existing file", () => {
-        const thisProject = InMemoryProject.of({path: "package.json", content: "{ node: true }"});
+        const thisProject = InMemoryProject.of({ path: "package.json", content: "{ node: true }" });
         assert(thisProject.fileExistsSync("package.json"));
     });
 
     it("fileExistsSync: no such file", () => {
-        const thisProject = InMemoryProject.of({path: "package.json", content: "{ node: true }"});
+        const thisProject = InMemoryProject.of({ path: "package.json", content: "{ node: true }" });
         assert(!thisProject.fileExistsSync("xxxxpackage.json"));
     });
 
     it("files returns enough files", done => {
         const thisProject = InMemoryProject.of(
-            {path: "package.json", content: "{ node: true }"},
-            {path: "package-lock.json", content: "{ node: true }"},
+            { path: "package.json", content: "{ node: true }" },
+            { path: "package-lock.json", content: "{ node: true }" },
         );
 
         assert(toPromise(thisProject.streamFiles())
@@ -47,16 +47,16 @@ describe("InMemoryProject", () => {
     it("streamFiles returns enough files", done => {
         let count = 0;
         const thisProject = InMemoryProject.of(
-            {path: "package.json", content: "{ node: true }"},
-            {path: "package-lock.json", content: "{ node: true }"},
+            { path: "package.json", content: "{ node: true }" },
+            { path: "package-lock.json", content: "{ node: true }" },
         );
         thisProject.streamFiles()
             .on("data", (f: File) => {
-                    // console.log(`File path is [${f.path}]`);
-                    assert(f.name);
-                    count++;
-                },
-            ).on("end", () => {
+                // console.log(`File path is [${f.path}]`);
+                assert(f.name);
+                count++;
+            },
+        ).on("end", () => {
             assert(count === 2);
             done();
         });
@@ -65,17 +65,17 @@ describe("InMemoryProject", () => {
     it("streamFiles excludes glob non-matches", done => {
         let count = 0;
         const thisProject = InMemoryProject.of(
-            {path: "config/thing.js", content: "{ node: true }"},
-            {path: "config/other.ts", content: "{ node: true }"},
-            {path: "notconfig/other.ts", content: "{ node: true }"},
+            { path: "config/thing.js", content: "{ node: true }" },
+            { path: "config/other.ts", content: "{ node: true }" },
+            { path: "notconfig/other.ts", content: "{ node: true }" },
         );
         thisProject.streamFiles("config/**")
             .on("data", (f: File) => {
-                    // console.log(`File path is [${f.path}]`);
-                    assert(f.name);
-                    count++;
-                },
-            ).on("end", () => {
+                // console.log(`File path is [${f.path}]`);
+                assert(f.name);
+                count++;
+            },
+        ).on("end", () => {
             assert(count === 2, "Found " + count);
             done();
         });
@@ -83,8 +83,8 @@ describe("InMemoryProject", () => {
 
     it("files returns well-known files", done => {
         const thisProject = InMemoryProject.of(
-            {path: "package.json", content: "{ node: true }"},
-            {path: "package-lock.json", content: "{ node: true }"},
+            { path: "package.json", content: "{ node: true }" },
+            { path: "package-lock.json", content: "{ node: true }" },
         );
         toPromise(thisProject.streamFiles())
             .then(files => {
@@ -95,8 +95,8 @@ describe("InMemoryProject", () => {
 
     it("glob returns well-known file", done => {
         const thisProject = InMemoryProject.of(
-            {path: "package.json", content: "{ node: true }"},
-            {path: "package-lock.json", content: "{ node: true }"},
+            { path: "package.json", content: "{ node: true }" },
+            { path: "package-lock.json", content: "{ node: true }" },
         );
         toPromise(thisProject.streamFiles("package.json"))
             .then(files => {
@@ -107,8 +107,8 @@ describe("InMemoryProject", () => {
 
     it("file count", done => {
         const thisProject = InMemoryProject.of(
-            {path: "package.json", content: "{ node: true }"},
-            {path: "package-lock.json", content: "{ node: true }"},
+            { path: "package.json", content: "{ node: true }" },
+            { path: "package-lock.json", content: "{ node: true }" },
         );
         thisProject.totalFileCount().then(num => {
             assert(num > 0);
@@ -180,6 +180,139 @@ describe("InMemoryProject", () => {
                 assert(!f2);
                 done();
             }).catch(done);
+    });
+
+    const deleteTestFiles = [
+        { path: "README.md", content: "# This project\n" },
+        { path: "LICENSE", content: "The license.\n" },
+        { path: "CODE_OF_CONDUCT.md", content: "The code.\n" },
+        { path: "CONTRIBUTING.md", content: "Contribute.\n" },
+        { path: "src/main/java/Command.java", content: "package main" },
+        { path: ".travis/travis-build.bash", content: "#!/bin/bash\n" },
+        { path: ".travis/some.patch", content: "--- a/c.d\n+++ b/c.d\n" },
+        { path: "src/test/scala/CommandTest.scala", content: "package main" },
+        { path: ".travis-save/travis-build.bash", content: "#!/bin/bash\necho save me\n" },
+    ];
+    const deleteTestDirs = [
+        ".travis",
+        ".travis-save",
+        "src",
+        "src/main",
+        "src/main/java",
+        "src/test",
+        "src/test/scala",
+    ];
+
+    it("should sync delete a file", () => {
+        const p = InMemoryProject.of(...deleteTestFiles);
+        const paths = deleteTestFiles.map(f => f.path);
+        const remove = ["CODE_OF_CONDUCT.md"];
+        const remain = paths.filter(f => !remove.includes(f));
+        remove.forEach(f => p.deleteFileSync(f));
+        remain.forEach(f => assert(p.fileExistsSync(f)));
+        remove.forEach(f => assert(!p.fileExistsSync(f)));
+        deleteTestDirs.forEach(d => assert(p.directoryExistsSync(d)));
+    });
+
+    it("should async delete a file", done => {
+        const p = InMemoryProject.of(...deleteTestFiles);
+        const paths = deleteTestFiles.map(f => f.path);
+        const remove = ["CODE_OF_CONDUCT.md"];
+        const remain = paths.filter(f => !remove.includes(f));
+        Promise.all(remove.map(f => p.deleteFile(f)))
+            .then(() => {
+                remain.forEach(f => assert(p.fileExistsSync(f)));
+                remove.forEach(f => assert(!p.fileExistsSync(f)));
+                deleteTestDirs.forEach(d => assert(p.directoryExistsSync(d)));
+            })
+            .then(done, done);
+    });
+
+    it("should sync delete files", () => {
+        const p = InMemoryProject.of(...deleteTestFiles);
+        const paths = deleteTestFiles.map(f => f.path);
+        const remove = ["CODE_OF_CONDUCT.md", ".travis/some.patch"];
+        const remain = paths.filter(f => !remove.includes(f));
+        remove.forEach(f => p.deleteFileSync(f));
+        remain.forEach(f => assert(p.fileExistsSync(f)));
+        remove.forEach(f => assert(!p.fileExistsSync(f)));
+        deleteTestDirs.forEach(d => assert(p.directoryExistsSync(d)));
+    });
+
+    it("should async delete files", done => {
+        const p = InMemoryProject.of(...deleteTestFiles);
+        const paths = deleteTestFiles.map(f => f.path);
+        const remove = ["CODE_OF_CONDUCT.md", ".travis/some.patch"];
+        const remain = paths.filter(f => !remove.includes(f));
+        Promise.all(remove.map(f => p.deleteFile(f)))
+            .then(() => {
+                remain.forEach(f => assert(p.fileExistsSync(f)));
+                remove.forEach(f => assert(!p.fileExistsSync(f)));
+                deleteTestDirs.forEach(d => assert(p.directoryExistsSync(d)));
+            })
+            .then(done, done);
+    });
+
+    it("should sync delete a file and empty directories", () => {
+        const p = InMemoryProject.of(...deleteTestFiles);
+        const paths = deleteTestFiles.map(f => f.path);
+        const remove = ["CODE_OF_CONDUCT.md", "src/main/java/Command.java"];
+        const remain = paths.filter(f => !remove.includes(f));
+        const removeDirs = ["src/main", "src/main/java"];
+        const remainDirs = deleteTestDirs.filter(d => !removeDirs.includes(d));
+        remove.forEach(f => p.deleteFileSync(f));
+        remain.forEach(f => assert(p.fileExistsSync(f)));
+        remove.forEach(f => assert(!p.fileExistsSync(f)));
+        remainDirs.forEach(d => assert(p.directoryExistsSync(d)));
+        removeDirs.forEach(d => assert(!p.directoryExistsSync(d)));
+    });
+
+    it("should async delete a file and empty directories", done => {
+        const p = InMemoryProject.of(...deleteTestFiles);
+        const paths = deleteTestFiles.map(f => f.path);
+        const remove = ["CODE_OF_CONDUCT.md", "src/main/java/Command.java"];
+        const remain = paths.filter(f => !remove.includes(f));
+        const removeDirs = ["src/main", "src/main/java"];
+        const remainDirs = deleteTestDirs.filter(d => !removeDirs.includes(d));
+        Promise.all(remove.map(f => p.deleteFile(f)))
+            .then(() => {
+                remain.forEach(f => assert(p.fileExistsSync(f)));
+                remove.forEach(f => assert(!p.fileExistsSync(f)));
+                remainDirs.forEach(d => assert(p.directoryExistsSync(d)));
+                removeDirs.forEach(d => assert(!p.directoryExistsSync(d)));
+            })
+            .then(done, done);
+    });
+
+    it("should sync delete a directory and its contents", () => {
+        const p = InMemoryProject.of(...deleteTestFiles);
+        const paths = deleteTestFiles.map(f => f.path);
+        const removeDirs = [".travis"];
+        const remainDirs = deleteTestDirs.filter(d => !removeDirs.includes(d));
+        const remove = [".travis/travis-build.bash", ".travis/some.patch"];
+        const remain = paths.filter(f => !remove.includes(f));
+        removeDirs.forEach(d => p.deleteDirectorySync(d));
+        remain.forEach(f => assert(p.fileExistsSync(f)));
+        remove.forEach(f => assert(!p.fileExistsSync(f)));
+        remainDirs.forEach(d => assert(p.directoryExistsSync(d)));
+        removeDirs.forEach(d => assert(!p.directoryExistsSync(d)));
+    });
+
+    it("should async delete a file and empty directories", done => {
+        const p = InMemoryProject.of(...deleteTestFiles);
+        const paths = deleteTestFiles.map(f => f.path);
+        const removeDirs = [".travis"];
+        const remainDirs = deleteTestDirs.filter(d => !removeDirs.includes(d));
+        const remove = [".travis/travis-build.bash", ".travis/some.patch"];
+        const remain = paths.filter(f => !remove.includes(f));
+        Promise.all(removeDirs.map(d => p.deleteDirectory(d)))
+            .then(() => {
+                remain.forEach(f => assert(p.fileExistsSync(f)));
+                remove.forEach(f => assert(!p.fileExistsSync(f)));
+                remainDirs.forEach(d => assert(p.directoryExistsSync(d)));
+                removeDirs.forEach(d => assert(!p.directoryExistsSync(d)));
+            })
+            .then(done, done);
     });
 
 });


### PR DESCRIPTION
RemoveSeedFiles is neither generic enough nor helpful enough.  It is
easy enough to delete files and directories.

Fix some issues with InMemoryProject file and directory deletions,
including, for example, deleting the file `foobar` if the directory
`foo` was being deleted.  Add tests for deleting files and directories
from InMemoryProject.

AllFiles glob had superfluous `/**`, `**` should be sufficient.