### PR TITLE
Report metrics on clone caching

### DIFF
--- a/src/automationClient.ts
+++ b/src/automationClient.ts
@@ -28,8 +28,8 @@ import { toStringArray } from "./internal/util/string";
 import { AutomationServer } from "./server/AutomationServer";
 import { BuildableAutomationServer } from "./server/BuildableAutomationServer";
 import { AutomationServerOptions } from "./server/options";
-import { Maker } from "./util/constructionUtils";
 import { logCachingDirectoryManagerMetricsAllDay } from "./spi/clone/CachingDirectoryManager";
+import { Maker } from "./util/constructionUtils";
 
 export const DefaultApiServer =
     "https://automation.atomist.com/registration";

--- a/src/automationClient.ts
+++ b/src/automationClient.ts
@@ -29,6 +29,7 @@ import { AutomationServer } from "./server/AutomationServer";
 import { BuildableAutomationServer } from "./server/BuildableAutomationServer";
 import { AutomationServerOptions } from "./server/options";
 import { Maker } from "./util/constructionUtils";
+import { logCachingDirectoryManagerMetricsAllDay } from "./spi/clone/CachingDirectoryManager";
 
 export const DefaultApiServer =
     "https://automation.atomist.com/registration";
@@ -101,6 +102,9 @@ export class AutomationClient {
         if (this.configuration.logging && this.configuration.logging.level) {
             (logger as any).level = this.configuration.logging.level;
         }
+
+        logCachingDirectoryManagerMetricsAllDay()
+            .catch(error => logger.error("logging of clone-caching metrics failed: " + error));
 
         if (!(this.configuration.cluster && this.configuration.cluster.enabled)) {
             logger.info(`Starting Atomist automation client ${this.configuration.name}@${this.configuration.version}`);

--- a/src/spi/clone/CachingDirectoryManager.ts
+++ b/src/spi/clone/CachingDirectoryManager.ts
@@ -90,9 +90,9 @@ export function logCachingDirectoryManagerMetricsAllDay(): Promise<void> {
         .then(() => logCachingDirectoryManagerMetricsAllDay());
 }
 
-export type PerRepoCachingMetrics = {
-    reuses: number,
-    fallbacks: number,
+export interface PerRepoCachingMetrics {
+    reuses: number;
+    fallbacks: number;
 }
 
 class CachingOfClonesMetricsCache {
@@ -122,7 +122,6 @@ class CachingOfClonesMetricsCache {
         this.fallbackCounts[keyFor(repoId)]++;
     }
 
-
 }
 
 function keyFor(repoId: RepoId) {
@@ -136,10 +135,10 @@ export class CachingOfClonesMetrics {
 
     constructor(reuseCounts: any, fallbackCounts: any) {
         this.reuseCounts = {
-            ...reuseCounts
+            ...reuseCounts,
         };
         this.fallbackCounts = {
-            ...fallbackCounts
+            ...fallbackCounts,
         };
     }
 
@@ -147,7 +146,7 @@ export class CachingOfClonesMetrics {
         return {
             reuses: this.reuseCounts[keyFor(repoId)] || 0,
             fallbacks: this.fallbackCounts[keyFor(repoId)] || 0,
-        }
+        };
     }
 
     public print(): string {
@@ -171,7 +170,6 @@ export interface CachingOfClonesMetricsReporting {
 }
 
 const CachingOfClonesMetricsCacheImpl = new CachingOfClonesMetricsCache();
-
 
 /*
  * file locking. only used here


### PR DESCRIPTION
This will report about cached clone hits and misses every 10 minutes, both in total and per repo.

I suspect you might want to change the implementation of the "all day" part, the logCachingDirectoryManagerMetricsAllDay method.