### PR TITLE
re-use existing metrics infrastructure for directory caching

### DIFF
--- a/src/automationClient.ts
+++ b/src/automationClient.ts
@@ -28,8 +28,8 @@ import { toStringArray } from "./internal/util/string";
 import { AutomationServer } from "./server/AutomationServer";
 import { BuildableAutomationServer } from "./server/BuildableAutomationServer";
 import { AutomationServerOptions } from "./server/options";
-import { Maker } from "./util/constructionUtils";
 import { logCachingDirectoryManagerMetricsAllDay } from "./spi/clone/CachingDirectoryManager";
+import { Maker } from "./util/constructionUtils";
 
 export const DefaultApiServer =
     "https://automation.atomist.com/registration";

--- a/src/automationClient.ts
+++ b/src/automationClient.ts
@@ -28,7 +28,6 @@ import { toStringArray } from "./internal/util/string";
 import { AutomationServer } from "./server/AutomationServer";
 import { BuildableAutomationServer } from "./server/BuildableAutomationServer";
 import { AutomationServerOptions } from "./server/options";
-import { logCachingDirectoryManagerMetricsAllDay } from "./spi/clone/CachingDirectoryManager";
 import { Maker } from "./util/constructionUtils";
 
 export const DefaultApiServer =
@@ -102,9 +101,6 @@ export class AutomationClient {
         if (this.configuration.logging && this.configuration.logging.level) {
             (logger as any).level = this.configuration.logging.level;
         }
-
-        logCachingDirectoryManagerMetricsAllDay()
-            .catch(error => logger.error("logging of clone-caching metrics failed: " + error));
 
         if (!(this.configuration.cluster && this.configuration.cluster.enabled)) {
             logger.info(`Starting Atomist automation client ${this.configuration.name}@${this.configuration.version}`);

--- a/src/automationClient.ts
+++ b/src/automationClient.ts
@@ -29,6 +29,7 @@ import { AutomationServer } from "./server/AutomationServer";
 import { BuildableAutomationServer } from "./server/BuildableAutomationServer";
 import { AutomationServerOptions } from "./server/options";
 import { Maker } from "./util/constructionUtils";
+import { logCachingDirectoryManagerMetricsAllDay } from "./spi/clone/CachingDirectoryManager";
 
 export const DefaultApiServer =
     "https://automation.atomist.com/registration";
@@ -101,6 +102,9 @@ export class AutomationClient {
         if (this.configuration.logging && this.configuration.logging.level) {
             (logger as any).level = this.configuration.logging.level;
         }
+
+        logCachingDirectoryManagerMetricsAllDay()
+            .catch(error => logger.error("logging of clone-caching metrics failed: " + error));
 
         if (!(this.configuration.cluster && this.configuration.cluster.enabled)) {
             logger.info(`Starting Atomist automation client ${this.configuration.name}@${this.configuration.version}`);

--- a/src/internal/util/metric.ts
+++ b/src/internal/util/metric.ts
@@ -4,16 +4,24 @@ import * as os from "os";
 const report = new _metrics.Report();
 
 export function increment(name: string) {
-    const counter = report.getMetric(name) as _metrics.Counter || new _metrics.Counter();
+    const counter = getCounter(name);
     counter.inc();
     report.addMetric(name, counter);
 }
 
 // tslint:disable-next-line:no-shadowed-variable
 export function duration(name: string, duration: number) {
-    const timer = report.getMetric(name) as _metrics.Timer || new _metrics.Timer();
+    const timer = getTimer(name);
     timer.update(duration);
     report.addMetric(name, timer);
+}
+
+export function getCounter(name: string): _metrics.Counter {
+    return report.getMetric(name) as _metrics.Counter || new _metrics.Counter();
+}
+
+export function getTimer(name: string): _metrics.Timer {
+    return report.getMetric(name) as _metrics.Timer || new _metrics.Timer();
 }
 
 export function metrics() {

--- a/src/spi/clone/CachingDirectoryManager.ts
+++ b/src/spi/clone/CachingDirectoryManager.ts
@@ -90,9 +90,9 @@ export function logCachingDirectoryManagerMetricsAllDay(): Promise<void> {
         .then(() => logCachingDirectoryManagerMetricsAllDay());
 }
 
-export type PerRepoCachingMetrics = {
-    reuses: number,
-    fallbacks: number,
+export interface PerRepoCachingMetrics {
+    reuses: number;
+    fallbacks: number;
 }
 
 class CachingOfClonesMetricsCache {
@@ -122,7 +122,6 @@ class CachingOfClonesMetricsCache {
         this.fallbackCounts[keyFor(repoId)]++;
     }
 
-
 }
 
 function keyFor(repoId: RepoId) {
@@ -136,10 +135,10 @@ export class CachingOfClonesMetrics {
 
     constructor(reuseCounts: any, fallbackCounts: any) {
         this.reuseCounts = {
-            ...reuseCounts
+            ...reuseCounts,
         };
         this.fallbackCounts = {
-            ...fallbackCounts
+            ...fallbackCounts,
         };
     }
 
@@ -147,7 +146,7 @@ export class CachingOfClonesMetrics {
         return {
             reuses: this.reuseCounts[keyFor(repoId)] || 0,
             fallbacks: this.fallbackCounts[keyFor(repoId)] || 0,
-        }
+        };
     }
 
     public print(): string {
@@ -171,7 +170,6 @@ export interface CachingOfClonesMetricsReporting {
 }
 
 const CachingOfClonesMetricsCacheImpl = new CachingOfClonesMetricsCache();
-
 
 /*
  * file locking. only used here

--- a/test/project/git/CachedGitCloneTest.ts
+++ b/test/project/git/CachedGitCloneTest.ts
@@ -15,7 +15,7 @@ import { GitHubToken } from "../../atomist.config";
 
 const Creds = { token: GitHubToken };
 const Owner = "atomist-travisorg";
-const RepoName = "this-repository-exists"
+const RepoName = "this-repository-exists";
 
 function reuseKey(repo: string): string {
     return `${ReuseKey}.${Owner}/${repo}`;


### PR DESCRIPTION
This takes @jessitron's changes from #140 and integrates it into the client's metrics infrastructure. 

With this, metrics are available form the metrics endpoint at `http://localhost:2866/metrics`.