### PR TITLE
Fix clone token, unify repo creation, move cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 -   **Breaking** Removed old class hierarchy for editors, generators and reviewers
     (`AbstractGenerator/UniversalSeed etc). Use new functional style as in `spring-automation`.
 -   The `AllFiles` glob pattern was simplified to `**`
+-   Move cache directory to ~/.atomist/cache
 
 ### Fixed
 
 -   Issues with deleting files and directories in an InMemoryProject
+-   Ensure GitHub sees a token in a clone URL as a token
 
 ### Removed
 

--- a/src/operations/common/RepoId.ts
+++ b/src/operations/common/RepoId.ts
@@ -13,7 +13,7 @@ export interface RepoId {
 
 export class SimpleRepoId implements RepoId {
 
-    constructor(public owner: string, public repo: string) {}
+    constructor(public owner: string, public repo: string) { }
 }
 
 /**
@@ -82,7 +82,7 @@ export class RemoteRepoRefSupport implements RemoteRepoRef {
     }
 
     public cloneUrl(creds: ProjectOperationCredentials) {
-        return `https://${creds.token}@${this.remoteBase}/${this.pathComponent}.git`;
+        return `https://${creds.token}:x-oauth-basic@${this.remoteBase}/${this.pathComponent}.git`;
     }
 
     get pathComponent(): string {

--- a/src/spi/clone/CachingDirectoryManager.ts
+++ b/src/spi/clone/CachingDirectoryManager.ts
@@ -1,4 +1,5 @@
 import * as os from "os";
+import * as path from "path";
 import { logger } from "../../internal/util/logger";
 import {
     CloneDirectoryInfo,
@@ -8,9 +9,9 @@ import {
 import { StableDirectoryManager } from "./StableDirectoryManager";
 import { TmpDirectoryManager } from "./tmpDirectoryManager";
 
-const AtomistWorkingDirectory = ".atomist-editing";
+const AtomistWorkingDirectory = path.join(".atomist", "cache");
 
-const AbsoluteAtomistWorkingDirectory = os.homedir() + "/" + AtomistWorkingDirectory;
+const AbsoluteAtomistWorkingDirectory = path.join(os.homedir(), AtomistWorkingDirectory);
 
 const cache = new StableDirectoryManager({
     reuseDirectories: true,
@@ -107,9 +108,9 @@ export { pleaseLock, LockResult, LockAcquired, NoLockForYou };
 
 type LockResult = LockAcquired | NoLockForYou;
 
-function pleaseLock(path: string): Promise<LockResult> {
+function pleaseLock(lockPath: string): Promise<LockResult> {
     return new Promise<LockResult>((resolve, reject) => {
-        lockfile.lock(path, (error, releaseCallback) => {
+        lockfile.lock(lockPath, (error, releaseCallback) => {
             if (error) {
                 if (error.code === "ELOCKED") {
                     resolve({ success: false, error });

--- a/test/project/git/CachedGitCloneTest.ts
+++ b/test/project/git/CachedGitCloneTest.ts
@@ -81,11 +81,11 @@ describe("cached git clone projects", () => {
                     clone2.createBranch("banana")
                         .then(() => clone2.push())
                         .then(() => assert.fail("that shouldn't work with an invalid token"),
-                            error => {
-                                // I did expect that to fail
-                                assert(0 <= error.message.indexOf("https://NOT-THE-SAME-YO@github.com"),
-                                    error.message);
-                            })
+                        error => {
+                            // I did expect that to fail
+                            assert(0 <= error.message.indexOf("https://NOT-THE-SAME-YO:x-oauth-basic@github.com"),
+                                error.message);
+                        })
                         .then(() => clone2.release()));
         }).then(done, done);
     }).timeout(20000);


### PR DESCRIPTION
Unify repo creation and move it to gitHub.ts.  Centralize creation of
the clone URL and ensure the token in the clone URL is always viewed
as such by GitHub.

Create directories with fs-extra.ensureDir, it is a lot easier and
more reliable.

Move repo cache to ~/.atomist/cache/repos/github.com/OWNER/REPO.

Closes #63