### PR TITLE
The Silence of the Tests

### DIFF
--- a/src/action/actionOps.ts
+++ b/src/action/actionOps.ts
@@ -47,13 +47,13 @@ function toAction<T>(link: Chainable<T>): TAction<T> {
             return oneOrTheOther
                 .catch(err => failureOn(p, err, link))
                 .then(r => {
-                // See what it returns
-                return isActionResult(r) ?
-                    r :
-                    successOn(r) as ActionResult<T>;
-            });
+                    // See what it returns
+                    return isActionResult(r) ?
+                        r :
+                        successOn(r) as ActionResult<T>;
+                });
         } catch (error) {
-            console.log("There was a failure yo!" + error.message);
+            console.error("Failure: " + error.message);
             return Promise.resolve(failureOn(p, error, link));
         }
     };

--- a/src/internal/transport/AbstractRequestProcessor.ts
+++ b/src/internal/transport/AbstractRequestProcessor.ts
@@ -42,7 +42,7 @@ export abstract class AbstractRequestProcessor implements RequestProcessor {
     }
 
     public processCommand(command: CommandIncoming,
-                          // tslint:disable-next-line:no-empty
+        // tslint:disable-next-line:no-empty
                           callback: (result: Promise<HandlerResult>) => void = () => { }) {
         // setup context
         const ses = namespace.init();
@@ -82,7 +82,7 @@ export abstract class AbstractRequestProcessor implements RequestProcessor {
     }
 
     public processEvent(event: EventIncoming,
-                        // tslint:disable-next-line:no-empty
+        // tslint:disable-next-line:no-empty
                         callback: (results: Promise<HandlerResult[]>) => void = () => { }) {
         // setup context
         const ses = namespace.init();

--- a/src/project/git/GitCommandGitProject.ts
+++ b/src/project/git/GitCommandGitProject.ts
@@ -334,7 +334,7 @@ function cloneInto(credentials: ProjectOperationCredentials,
         runIn(".", `git clone ${id.cloneUrl(credentials)} ${repoDir}`)
             .then(() => runIn(repoDir, `git checkout ${id.sha} --`));
 
-    logger.info(`Cloning repo '${id.url}' in '${repoDir}'`);
+    logger.debug(`Cloning repo '${id.url}' in '${repoDir}'`);
     return command
         .then(_ => {
             logger.debug(`Clone succeeded with URL '${id.url}'`);

--- a/src/project/util/jsonUtils.ts
+++ b/src/project/util/jsonUtils.ts
@@ -14,9 +14,12 @@ export type JsonManipulation = (jsonObj: any) => void;
  * @param {JsonManipulation} manipulation
  * @return {Promise<P extends ProjectAsync>}
  */
-export function doWithJson<M, P extends ProjectAsync = ProjectAsync>(p: P,
-                                                                     jsonPath: string,
-                                                                     manipulation: JsonManipulation): Promise<P> {
+export function doWithJson<M, P extends ProjectAsync = ProjectAsync>(
+    p: P,
+    jsonPath: string,
+    manipulation: JsonManipulation,
+): Promise<P> {
+
     return doWithFiles(p, jsonPath, file => {
         return file.getContent()
             .then(content => {
@@ -27,7 +30,7 @@ export function doWithJson<M, P extends ProjectAsync = ProjectAsync>(p: P,
     });
 }
 
-const spacePossibilities = [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, " ", "  ", "\t"];
+const spacePossibilities = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, " ", "  ", "\t"];
 
 /**
  * Update the object form of the given JSON content and write
@@ -48,13 +51,13 @@ export function manipulate(jsonIn: string, manipulation: JsonManipulation, conte
         for (const sp of spacePossibilities) {
             const maybe = JSON.stringify(obj, null, sp);
             if (jsonIn === maybe) {
-                console.log(`Definitely inferred space as [${sp}]`);
+                logger.debug(`Definitely inferred space as [${sp}]`);
                 space = sp;
                 break;
             }
         }
 
-        console.log(`Inferred space is [${space}]`);
+        logger.debug(`Inferred space is [${space}]`);
 
         manipulation(obj);
         return JSON.stringify(obj, null, space);

--- a/src/server/BuildableAutomationServer.ts
+++ b/src/server/BuildableAutomationServer.ts
@@ -77,7 +77,7 @@ export class BuildableAutomationServer extends AbstractAutomationServer {
                 if (teamId) {
                     if (opts.token) {
                         this.graphClient = new ApolloGraphClient(`${opts.endpoints.graphql}/${teamId}`,
-                            {Authorization: `token ${opts.token}`});
+                            { Authorization: `token ${opts.token}` });
                     } else {
                         logger.warn("Cannot create graph client due to missing token");
                     }

--- a/src/spi/clone/StableDirectoryManager.ts
+++ b/src/spi/clone/StableDirectoryManager.ts
@@ -55,7 +55,7 @@ export class StableDirectoryManager implements DirectoryManager {
     public invalidate(existing: CloneDirectoryInfo): Promise<void> {
         return fs.remove(existing.path)
             .then(() => {
-                logger.info("Deleted " + existing.path);
+                logger.debug("Deleted " + existing.path);
             }, err => {
                 if (err.code === "ENOENT") {
                     logger.debug("Cleanup: deleting %s, but it's already gone", existing.path);

--- a/src/tree/ast/FileHits.ts
+++ b/src/tree/ast/FileHits.ts
@@ -21,7 +21,7 @@ export interface NodeReplacementOptions {
  */
 export const ZapTrailingWhitespace: NodeReplacementOptions = {
 
-    replaceAfter: {after: /\s*/, replacement: ""},
+    replaceAfter: { after: /\s*/, replacement: "" },
 };
 
 /**
@@ -113,20 +113,20 @@ function makeUpdatable(matches: MatchResult[], updates: Update[]) {
                 return currentValue;
             },
             set(v2) {
-                logger.info("Updating value from '%s' to '%s' on '%s'", currentValue, v2, m.$name);
+                logger.debug("Updating value from '%s' to '%s' on '%s'", currentValue, v2, m.$name);
                 // TODO allow only one
                 currentValue = v2;
-                updates.push({initialValue, currentValue, offset: m.$offset});
+                updates.push({ initialValue, currentValue, offset: m.$offset });
             },
         });
         m.append = (content: string) => {
-            updates.push({initialValue: "", currentValue: content, offset: m.$offset + currentValue.length});
+            updates.push({ initialValue: "", currentValue: content, offset: m.$offset + currentValue.length });
         };
         m.prepend = (content: string) => {
-            updates.push({initialValue: "", currentValue: content, offset: m.$offset});
+            updates.push({ initialValue: "", currentValue: content, offset: m.$offset });
         };
         m.zap = (opts: NodeReplacementOptions) => {
-            updates.push({...opts, initialValue, currentValue: "", offset: m.$offset});
+            updates.push({ ...opts, initialValue, currentValue: "", offset: m.$offset });
         };
         m.evaluateExpression = (pex: PathExpression | string) => {
             const r = evaluateExpression(m, pex);

--- a/src/tree/ast/astUtils.ts
+++ b/src/tree/ast/astUtils.ts
@@ -42,7 +42,7 @@ export function findByExpression(p: ProjectAsync,
     }
     const globPattern = split[0];
     const pathExpression = _.drop(split, 1).join("");
-    logger.info("Glob is [%s], path expression [%s] from [%s]", globPattern, pathExpression, unifiedExpression);
+    logger.debug("Glob is [%s], path expression [%s] from [%s]", globPattern, pathExpression, unifiedExpression);
     return findMatches(p, parserOrRegistry, globPattern, pathExpression);
 }
 

--- a/src/tree/ast/typescript/TypeScriptFileParser.ts
+++ b/src/tree/ast/typescript/TypeScriptFileParser.ts
@@ -61,13 +61,13 @@ export class TypeScriptFileParser implements FileParser {
  */
 function scriptKindFor(f: File): ts.ScriptKind {
     switch (f.extension) {
-        case "js" :
+        case "js":
             return ts.ScriptKind.JS;
-        case "jsx" :
+        case "jsx":
             return ts.ScriptKind.JSX;
-        case "ts" :
+        case "ts":
             return ts.ScriptKind.TS;
-        case "tsx" :
+        case "tsx":
             return ts.ScriptKind.TSX;
         default:
             return ts.ScriptKind.Unknown;
@@ -98,7 +98,7 @@ class TypeScriptAstNodeTreeNode implements TreeNode {
             this.$offset = node.getStart(sourceFile, true);
         } catch (e) {
             // Ignore and continue
-            logger.warn("Cannot get start for node with kind %s", ts.SyntaxKind[node.kind]);
+            logger.debug("Cannot get start for node with kind %s", ts.SyntaxKind[node.kind]);
         }
 
         for (const n of node.getChildren(sourceFile)) {

--- a/test-api/ApolloGraphClientTest.ts
+++ b/test-api/ApolloGraphClientTest.ts
@@ -19,7 +19,7 @@ describe("ApolloGraphClient", () => {
         agc.executeQueryFromFile<ReposQuery, ReposQueryVariables>("graphql/repos",
             { teamId, offset: 0 })
             .then(result => {
-                console.log("query took " + (Date.now() - start));
+                console.debug("query took " + (Date.now() - start));
                 const org = result.ChatTeam[0].orgs[0];
                 assert(org.repo.length > 0);
                 const repo1 = org.repo[0];
@@ -29,7 +29,7 @@ describe("ApolloGraphClient", () => {
                 agc.executeQueryFromFile<ReposQuery, ReposQueryVariables>("graphql/repos",
                     { teamId, offset: 0 })
                     .then(r1 => {
-                        console.log("query took " + (Date.now() - start));
+                        console.debug("query took " + (Date.now() - start));
                     });
             })
             .then(done, done);
@@ -49,7 +49,7 @@ describe("ApolloGraphClient", () => {
                     .then(p => {
                         const gitHead = p.findFileSync(".git/HEAD");
                         assert(gitHead);
-                        console.log(`.git/HEAD path=${gitHead.path}`);
+                        assert(gitHead.path === ".git/HEAD");
                     });
             })
             .then(done, done);

--- a/test-api/credentials.ts
+++ b/test-api/credentials.ts
@@ -1,5 +1,9 @@
-import { LoggingConfig } from "../src/internal/util/logger";
+import * as winston from "winston";
+
+import { logger, LoggingConfig } from "../src/internal/util/logger";
+
 LoggingConfig.format = "cli";
+(logger as winston.LoggerInstance).level = process.env.LOG_LEVEL || "info";
 
 function barf(): string {
     throw new Error("<please set GITHUB_TOKEN env variable>");

--- a/test/configurationTest.ts
+++ b/test/configurationTest.ts
@@ -2,9 +2,6 @@ import "mocha";
 import * as assert from "power-assert";
 
 import { resolveModuleConfig, UserConfig } from "../src/configuration";
-import { LoggingConfig } from "../src/internal/util/logger";
-
-LoggingConfig.format = "cli";
 
 describe("configuration", () => {
 

--- a/test/credentials.ts
+++ b/test/credentials.ts
@@ -1,4 +1,10 @@
+import * as winston from "winston";
+
+import { logger, LoggingConfig } from "../src/internal/util/logger";
 import { GitHubRepoRef } from "../src/operations/common/GitHubRepoRef";
+
+LoggingConfig.format = "cli";
+(logger as winston.LoggerInstance).level = process.env.LOG_LEVEL || "info";
 
 function barf(): string {
     throw new Error("<please set GITHUB_TOKEN env variable>");

--- a/test/operations/support/editorUtilsTest.ts
+++ b/test/operations/support/editorUtilsTest.ts
@@ -21,9 +21,8 @@ describe("editorUtils", () => {
         GitCommandGitProject.cloned(Creds, RepoThatExists)
             .then(p => {
                 return editProjectUsingBranch(undefined, p, NoOpEditor,
-                    {branch: "dont-create-me-or-i-barf&&&####&&& we", message: "whocares"})
+                    { branch: "dont-create-me-or-i-barf&&&####&&& we", message: "whocares" })
                     .then(er => {
-                        console.log(p.baseDir);
                         assert(!er.edited);
                         done();
                     });

--- a/test/project/git/GitProjectTest.ts
+++ b/test/project/git/GitProjectTest.ts
@@ -131,8 +131,8 @@ describe("GitProject", () => {
             .then(() => gp.createAndSetGitHubRemote(owner, repo, "Thing1", TestRepositoryVisibility))
             .then(() => gp.commit("Added a Thing"))
             .then(() => gp.push()
-                    .then(() => deleteRepoIfExists({owner, repo}).then(done)),
-            ).catch(() => deleteRepoIfExists({owner, repo}).then(done)),
+                .then(() => deleteRepoIfExists({ owner, repo }).then(done)),
+        ).catch(() => deleteRepoIfExists({ owner, repo }).then(done)),
         ).catch(done);
 
     }).timeout(16000);
@@ -151,7 +151,7 @@ describe("GitProject", () => {
                         .then(() => gp.push())
                         .then(() => gp.raisePullRequest("Thing2", "Adds another character"))
                         .then(() => deleteRepoIfExists(ownerAndRepo));
-                }).catch( err => deleteRepoIfExists(ownerAndRepo)
+                }).catch(err => deleteRepoIfExists(ownerAndRepo)
                     .then(() => Promise.reject(err))))
             .then(() => done(), done);
 
@@ -197,7 +197,7 @@ export function newRepo(): Promise<{ owner: string, repo: string }> {
     const name = `test-repo-${new Date().getTime()}`;
     const description = "a thing";
     const url = `${GitHubDotComBase}/user/repos`;
-    console.log("Visibility is " + TestRepositoryVisibility);
+    console.debug("Visibility is " + TestRepositoryVisibility);
     return getOwnerByToken()
         .then(owner => axios.post(url, {
             name,
@@ -218,7 +218,7 @@ export function newRepo(): Promise<{ owner: string, repo: string }> {
 }
 
 export function deleteRepoIfExists(ownerAndRepo: { owner: string, repo: string }): Promise<any> {
-    console.log("Cleanup: deleting " + ownerAndRepo.repo);
+    console.debug("Cleanup: deleting " + ownerAndRepo.repo);
     const config = {
         headers: {
             Authorization: `token ${GitHubToken}`,
@@ -227,7 +227,7 @@ export function deleteRepoIfExists(ownerAndRepo: { owner: string, repo: string }
     const url = `${GitHubDotComBase}/repos/${ownerAndRepo.owner}/${ownerAndRepo.repo}`;
     return axios.delete(url, config)
         .catch(err => {
-            console.log(`error deleting ${ownerAndRepo.repo}, ignoring. ${err.response.status}`);
+            console.error(`error deleting ${ownerAndRepo.repo}, ignoring. ${err.response.status}`);
         });
 }
 

--- a/test/tree/ast/typescript/conversionTests.ts
+++ b/test/tree/ast/typescript/conversionTests.ts
@@ -39,10 +39,10 @@ describe("path expression driven conversion", () => {
             "src/**/*.ts",
             "//VariableDeclaration//ColonToken[/following-sibling::*]")
             .then(values => {
-                console.log(stringify(values[0],
-                    (key, value) => ["$parent", "node", "sourceFile"].includes(key) ? undefined : value, 2));
+                // console.log(stringify(values[0],
+                //    (key, value) => ["$parent", "node", "sourceFile"].includes(key) ? undefined : value, 2));
                 assert(values.length === 1);
-                console.log(`Value is [${values[0].$value}]`);
+                // console.log(`Value is [${values[0].$value}]`);
                 assert(values[0].$value === ":");
                 done();
             }).catch(done);


### PR DESCRIPTION
I noticed tokens were in the test output.  This alarmed me.
Fortunately, Travis CI scrapes the logs and replaces them with
`[secure]`.  Nonetheless, I took the opportunity to remove them by
default, raising the logging level in the tests to "info".  Any higher
and the mocha output is removed.  I also elevated some logs to debug
to quiet the logs even further.  There are still some logs output in
tests.  I left this in as I felt their current level was appropriate.

You can get the verbose logging back by running the tests like this:

```
$ LOG_LEVEL=debug GITHUB_TOKEN=YOUR_TOKEN npm test
```