### PR TITLE
Optionally add Atomist webhook to create repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
--   **Breaking** Removed old class hierarchy for editors, generators and reviewers
-    (`AbstractGenerator/UniversalSeed etc). Use new functional style as in `spring-automation`.
+-   **Breaking** Removed old class hierarchy for editors, generators
+    and reviewers (`AbstractGenerator/UniversalSeed`, etc), use new
+    functional style as in [spring-automation][]
 -   The `AllFiles` glob pattern was simplified to `**`
 -   Move cache directory to ~/.atomist/cache
 
@@ -24,6 +25,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 
 -   RemoveSeedFiles as it was not generic nor provided much convenience
+
+### Added
+
+-   Optionally add Atomist webhook to create GitHub repo
+
+[spring-automation]: https://github.com/atomist/spring-automation (@atomist/spring-automation)
 
 ## [0.4.0][] - 2017-11-28
 

--- a/src/internal/util/gitHub.ts
+++ b/src/internal/util/gitHub.ts
@@ -1,8 +1,0 @@
-
-import * as impl from "../../util/gitHub";
-
-/**
- * Exported only for backward compatible. Use util package.
- * @type {(token: string, user: string, repo: string, path: string) => Promise<boolean>}
- */
-export const hasFile = impl.hasFile;

--- a/src/operations/generate/BaseSeedDrivenGeneratorParameters.ts
+++ b/src/operations/generate/BaseSeedDrivenGeneratorParameters.ts
@@ -1,4 +1,4 @@
-import { Parameter, Parameters } from "../../decorators";
+import { MappedParameter, MappedParameters, Parameter, Parameters } from "../../decorators";
 import { SourceRepoParameters } from "../common/params/SourceRepoParameters";
 import { NewRepoCreationParameters } from "./NewRepoCreationParameters";
 
@@ -15,11 +15,15 @@ export class BaseSeedDrivenGeneratorParameters {
     @Parameter({
         pattern: /^(?:true|false)$/,
         type: "boolean",
-        displayName: "Add Atomist web hook",
-        description: "whether to add the Atomist web hook to the repository to allow updates",
+        displayName: "Add Atomist webhook",
+        description: "whether to add the Atomist webhook to the repository to allow updates",
+        validInput: "'true' or 'false'",
         required: false,
         displayable: true,
     })
     public addAtomistWebhook: boolean = false;
+
+    @MappedParameter(MappedParameters.GitHubWebHookUrl)
+    public webhookUrl: string;
 
 }

--- a/src/operations/generate/support/addAtomistWebhook.ts
+++ b/src/operations/generate/support/addAtomistWebhook.ts
@@ -1,6 +1,9 @@
-import { ActionResult, successOn } from "../../../action/ActionResult";
+import * as util from "util";
+
+import { ActionResult, failureOn, successOn } from "../../../action/ActionResult";
 import { logger } from "../../../internal/util/logger";
 import { GitProject } from "../../../project/git/GitProject";
+import { addRepoWebhook, GitHubRepoWebhookPayload } from "../../../util/gitHub";
 import { isGitHubRepoRef } from "../../common/GitHubRepoRef";
 import { ProjectAction } from "../../common/projectAction";
 import { BaseSeedDrivenGeneratorParameters } from "../BaseSeedDrivenGeneratorParameters";
@@ -13,24 +16,44 @@ import { BaseSeedDrivenGeneratorParameters } from "../BaseSeedDrivenGeneratorPar
  * @return {any}
  */
 export const addAtomistWebhook: ProjectAction<BaseSeedDrivenGeneratorParameters, GitProject> =
-    (p, params) => {
-        if (!params.addAtomistWebhook) {
-            return Promise.resolve(successOn(p));
-        } else {
-            return addWebhook(p)
-                .then(r => ({
-                    ...r,
-                    target: p,
-                }));
-        }
-    };
+    (p, params) => addWebhook(p, params)
+        .then(r => ({
+            ...r,
+            target: p,
+        }));
 
-function addWebhook(p: GitProject): Promise<ActionResult<any>> {
-    if (isGitHubRepoRef(p.id)) {
-        // TODO GitHub info is here
-        return Promise.resolve(successOn(p));
-    } else {
-        logger.warn("Unable to add Atomist web hook: Not a GitHub repo [%j]", p.id);
+function addWebhook(p: GitProject, params: BaseSeedDrivenGeneratorParameters): Promise<ActionResult<any>> {
+    if (!params.addAtomistWebhook) {
         return Promise.resolve(successOn(p));
     }
+
+    function logAndFail(fmt: string, ...args: any[]): Promise<ActionResult<GitProject>> {
+        const msg = util.format(fmt, ...args);
+        logger.error(msg);
+        return Promise.resolve(failureOn(p, new Error(msg), { name: "addWebhook" }));
+    }
+
+    if (!isGitHubRepoRef(p.id)) {
+        return logAndFail("Unable to add Atomist web hook: Not a GitHub repo [%j]", p.id);
+    }
+    if (!params.webhookUrl) {
+        return logAndFail("Requested to add webhook but no URL provided");
+    }
+    if (!params.target.githubToken) {
+        return logAndFail("Requested to add webhook but no GitHub token provided");
+    }
+
+    const payload: GitHubRepoWebhookPayload = {
+        name: "web",
+        events: ["*"],
+        active: true,
+        config: {
+            url: params.webhookUrl,
+            content_type: "json",
+        },
+    };
+    return addRepoWebhook(params.target.githubToken, p.id, payload)
+        .then(() => Promise.resolve(successOn(p)), err => {
+            return logAndFail("Failed to install Atomist webhook on %s/%s: %j", p.id.owner, p.id.repo, err);
+        });
 }

--- a/src/util/gitHub.ts
+++ b/src/util/gitHub.ts
@@ -78,6 +78,26 @@ export function raiseIssue(token: string, rr: RepoRef, issue: Issue): AxiosPromi
     return axios.post(url, issue, authHeaders(token));
 }
 
+export interface GitHubRepoWebhookConfig {
+    url: string;
+    content_type: "json" | "form";
+    secret?: string;
+    insecure_ssl?: string;
+}
+
+export interface GitHubRepoWebhookPayload {
+    name: "web";
+    events: string[];
+    active: boolean;
+    config: GitHubRepoWebhookConfig;
+}
+
+export function addRepoWebhook(token: string, rr: GitHubRepoRef, webhookData: GitHubRepoWebhookPayload): AxiosPromise {
+    const url = `${rr.apiBase}/repos/${rr.owner}/${rr.repo}/hooks`;
+    logger.debug(`Request to '${url}' to create webhook`);
+    return axios.post(url, webhookData, authHeaders(token));
+}
+
 /**
  * GitHub commit comment structure
  */


### PR DESCRIPTION
When generating a project, optionally create a webhook on the repo
with the Atomist webhook URL for that team.  Will add tests for this
functionality when #137 is complete.