### PR TITLE
Overhauled GitHub parameters to allow mapped parameter handling

### DIFF
--- a/src/operations/common/params/AllReposByDefaultParameters.ts
+++ b/src/operations/common/params/AllReposByDefaultParameters.ts
@@ -1,6 +1,7 @@
-import { Parameter, Parameters, Secret, Secrets } from "../../decorators";
-import { GitBranchRegExp, GitHubNameRegExp } from "../common/params/gitHubPatterns";
-import { RepoRef } from "../common/RepoId";
+import { Parameter, Parameters } from "../../../decorators";
+import { RepoRef } from "../RepoId";
+import { GitHubParams } from "./GitHubParams";
+import { GitBranchRegExp, GitHubNameRegExp } from "./gitHubPatterns";
 
 /**
  * Basic editor params. If owner and repo are specified, only the given
@@ -8,10 +9,7 @@ import { RepoRef } from "../common/RepoId";
  * will be edited.
  */
 @Parameters()
-export class BaseEditorParameters implements RepoRef {
-
-    @Secret(Secrets.userToken(["repo", "user"]))
-    public githubToken: string;
+export class AllReposByDefaultParameters extends GitHubParams implements RepoRef {
 
     @Parameter({description: "Name of owner to edit repo in", ...GitHubNameRegExp, required: false})
     public owner: string;

--- a/src/operations/common/params/AlwaysAskRepoParameters.ts
+++ b/src/operations/common/params/AlwaysAskRepoParameters.ts
@@ -1,0 +1,21 @@
+import { Parameter, Parameters } from "../../../decorators";
+import { RepoRef } from "../RepoId";
+import { GitHubParams } from "./GitHubParams";
+import { GitBranchRegExp, GitHubNameRegExp } from "./gitHubPatterns";
+
+/**
+ * Basic editor params. Always ask for a repo
+ */
+@Parameters()
+export class AlwaysAskRepoParameters extends GitHubParams implements RepoRef {
+
+    @Parameter({description: "Name of owner to edit repo in", ...GitHubNameRegExp, required: true})
+    public owner: string;
+
+    @Parameter({description: "Name of repo to edit", ...GitHubNameRegExp, required: true})
+    public repo: string;
+
+    @Parameter({description: "Branch or ref. Defaults to 'master'", ...GitBranchRegExp, required: false})
+    public sha: string;
+
+}

--- a/src/operations/common/params/GitHubParams.ts
+++ b/src/operations/common/params/GitHubParams.ts
@@ -1,0 +1,19 @@
+import { Parameters, Secret, Secrets } from "../../../decorators";
+import { RepoRef } from "../RepoId";
+
+/**
+ * Base parameters for working with GitHub repo(s)
+ */
+@Parameters()
+export abstract class GitHubParams implements RepoRef {
+
+    @Secret(Secrets.userToken(["repo", "user"]))
+    public githubToken: string;
+
+    public abstract owner;
+
+    public abstract repo;
+
+    public abstract sha;
+
+}

--- a/src/operations/common/params/MappedRepoParameters.ts
+++ b/src/operations/common/params/MappedRepoParameters.ts
@@ -1,0 +1,23 @@
+import { MappedParameter, MappedParameters, Parameter, Parameters } from "../../../decorators";
+import { RepoRef } from "../RepoId";
+import { GitHubParams } from "./GitHubParams";
+import { GitBranchRegExp } from "./gitHubPatterns";
+
+/**
+ * Basic editor params. If owner and repo are specified, only the given
+ * repo will be edited. Otherwise all repos accessible to the current team
+ * will be edited.
+ */
+@Parameters()
+export class MappedRepoParameters extends GitHubParams implements RepoRef {
+
+    @MappedParameter(MappedParameters.GitHubOwner)
+    public owner: string;
+
+    @MappedParameter(MappedParameters.GitHubRepository)
+    public repo: string;
+
+    @Parameter({description: "Branch or ref. Defaults to 'master'", ...GitBranchRegExp, required: false})
+    public sha: string;
+
+}

--- a/src/operations/edit/editAll.ts
+++ b/src/operations/edit/editAll.ts
@@ -25,15 +25,15 @@ import { AnyProjectEditor, EditResult, ProjectEditor, toEditor } from "./project
  * @param {RepoLoader} repoLoader
  * @return {Promise<Array<EditResult>>}
  */
-export function editAll<R, P>(ctx: HandlerContext,
-                              credentials: ProjectOperationCredentials,
-                              editor: AnyProjectEditor,
-                              editInfo: EditMode | EditModeFactory,
-                              parameters?: P,
-                              repoFinder: RepoFinder = allReposInTeam(),
-                              repoFilter: RepoFilter = AllRepos,
-                              repoLoader: RepoLoader =
-                                  defaultRepoLoader(credentials)): Promise<EditResult[]> {
+export function editAll<R, P extends RepoRef>(ctx: HandlerContext,
+                                              credentials: ProjectOperationCredentials,
+                                              editor: AnyProjectEditor,
+                                              editInfo: EditMode | EditModeFactory,
+                                              parameters?: P,
+                                              repoFinder: RepoFinder = allReposInTeam(),
+                                              repoFilter: RepoFilter = AllRepos,
+                                              repoLoader: RepoLoader =
+                                                  defaultRepoLoader(credentials)): Promise<EditResult[]> {
     const edit = (p: Project, parms: P) =>
         editRepo(ctx, p, toEditor(editor), toEditModeFactory(editInfo)(p), parms);
     return doWithAllRepos<EditResult, P>(ctx, credentials, edit, parameters,
@@ -51,13 +51,13 @@ export function editAll<R, P>(ctx: HandlerContext,
  * @param {RepoLoader} repoLoader (optional, useful in testing)
  * @return {Promise<EditResult>}
  */
-export function editOne<P = undefined>(ctx: HandlerContext,
-                                       credentials: ProjectOperationCredentials,
-                                       editor: AnyProjectEditor,
-                                       editInfo: EditMode,
-                                       singleRepository: RepoRef,
-                                       parameters?: P,
-                                       repoLoader: RepoLoader = defaultRepoLoader(credentials)): Promise<EditResult> {
+export function editOne<P extends RepoRef>(ctx: HandlerContext,
+                                           credentials: ProjectOperationCredentials,
+                                           editor: AnyProjectEditor,
+                                           editInfo: EditMode,
+                                           singleRepository: RepoRef,
+                                           parameters?: P,
+                                           repoLoader: RepoLoader = defaultRepoLoader(credentials)): Promise<EditResult> {
     const singleRepoFinder: RepoFinder = () => Promise.resolve([singleRepository]);
     return editAll(ctx, credentials, toEditor(editor), editInfo, parameters,
         singleRepoFinder, AllRepos, repoLoader)

--- a/src/operations/edit/editorToCommand.ts
+++ b/src/operations/edit/editorToCommand.ts
@@ -2,8 +2,8 @@ import { HandleCommand } from "../../HandleCommand";
 import { HandlerContext } from "../../HandlerContext";
 import { commandHandlerFrom, OnCommand, ParametersConstructor } from "../../onCommand";
 import { CommandDetails } from "../CommandDetails";
+import { AllReposByDefaultParameters } from "../common/params/AllReposByDefaultParameters";
 import { RepoFilter } from "../common/repoFilter";
-import { BaseEditorParameters } from "./BaseEditorParameters";
 import { editAll, editOne } from "./editAll";
 import { EditMode, isEditMode, PullRequest } from "./editModes";
 import { AnyProjectEditor } from "./projectEditor";
@@ -30,17 +30,17 @@ function defaultDetails(name: string): EditorCommandDetails {
 }
 
 /**
- * Create a handle function that edits one or many repos, following BaseEditorParameters
+ * Create a handle function that edits one or many repos, following AllReposByDefaultParameters
  * @param pe function returning a project editor instance appropriate for the parameters
  * @param {ParametersConstructor<PARAMS>} factory
  * @param {string} name
  * @param {string} details object allowing customization beyond reasonable defaults
  * @return {HandleCommand}
  */
-export function editorHandler<PARAMS extends BaseEditorParameters>(pe: (params: PARAMS) => AnyProjectEditor,
-                                                                   factory: ParametersConstructor<PARAMS>,
-                                                                   name: string,
-                                                                   details: Partial<EditorCommandDetails> = {}): HandleCommand {
+export function editorHandler<PARAMS extends AllReposByDefaultParameters>(pe: (params: PARAMS) => AnyProjectEditor,
+                                                                          factory: ParametersConstructor<PARAMS>,
+                                                                          name: string,
+                                                                          details: Partial<EditorCommandDetails> = {}): HandleCommand {
     const detailsToUse: EditorCommandDetails = {
         ...defaultDetails(name),
         ...details,
@@ -54,8 +54,8 @@ export function editorHandler<PARAMS extends BaseEditorParameters>(pe: (params: 
  * If owner and repo are required, edit just one repo. Otherwise edit all repos
  * in the present team
  */
-function handleEditOneOrMany<PARAMS extends BaseEditorParameters>(pe: (params: PARAMS) => AnyProjectEditor,
-                                                                  details: EditorCommandDetails): OnCommand<PARAMS> {
+function handleEditOneOrMany<PARAMS extends AllReposByDefaultParameters>(pe: (params: PARAMS) => AnyProjectEditor,
+                                                                         details: EditorCommandDetails): OnCommand<PARAMS> {
     return (ctx: HandlerContext, parameters: PARAMS) => {
         const credentials = {token: parameters.githubToken};
         if (!!parameters.owner && !!parameters.repo) {

--- a/src/operations/review/issueRaisingReviewRouter.ts
+++ b/src/operations/review/issueRaisingReviewRouter.ts
@@ -2,19 +2,19 @@
 import { failureOn, successOn } from "../../action/ActionResult";
 import { deepLink, Issue, raiseIssue } from "../../util/gitHub";
 import { GitHubRepoRef, isGitHubRepoRef } from "../common/GitHubRepoRef";
-import { BaseEditorParameters } from "../edit/BaseEditorParameters";
+import { AllReposByDefaultParameters } from "../common/params/AllReposByDefaultParameters";
 import { ReviewRouter } from "./reviewerToCommand";
 import { ProjectReview, ReviewComment } from "./ReviewResult";
 
 /**
  * Create an issue from a review, using Markdown
  * @param {ProjectReview} pr
- * @param {BaseEditorParameters} params
+ * @param {AllReposByDefaultParameters} params
  * @param {string} name
  * @return {any}
  */
-export const issueRaisingReviewRouter: ReviewRouter<BaseEditorParameters> =
-    (pr: ProjectReview, params: BaseEditorParameters, name: string) => {
+export const issueRaisingReviewRouter: ReviewRouter<AllReposByDefaultParameters> =
+    (pr: ProjectReview, params: AllReposByDefaultParameters, name: string) => {
         if (isGitHubRepoRef(pr.repoId)) {
             const issue = toIssue(pr, name);
             return raiseIssue(params.githubToken, pr.repoId, issue)

--- a/src/operations/review/reviewerToCommand.ts
+++ b/src/operations/review/reviewerToCommand.ts
@@ -4,10 +4,11 @@ import { HandlerContext } from "../../HandlerContext";
 import { commandHandlerFrom, OnCommand, ParametersConstructor } from "../../onCommand";
 import { CommandDetails } from "../CommandDetails";
 import { GitHubRepoRef } from "../common/GitHubRepoRef";
+import { AllReposByDefaultParameters } from "../common/params/AllReposByDefaultParameters";
+import { GitHubParams } from "../common/params/GitHubParams";
 import { RepoFilter } from "../common/repoFilter";
 import { RepoFinder } from "../common/repoFinder";
 import { RepoRef } from "../common/RepoId";
-import { BaseEditorParameters } from "../edit/BaseEditorParameters";
 import { issueRaisingReviewRouter } from "./issueRaisingReviewRouter";
 import { ProjectReviewer } from "./projectReviewer";
 import { reviewAll } from "./reviewAll";
@@ -19,7 +20,7 @@ export type ReviewRouter<PARAMS> = (pr: ProjectReview, params: PARAMS, title: st
 /**
  * Further details of an editor to allow selective customization
  */
-export interface ReviewerCommandDetails<PARAMS extends BaseEditorParameters> extends CommandDetails<PARAMS> {
+export interface ReviewerCommandDetails<PARAMS extends AllReposByDefaultParameters> extends CommandDetails<PARAMS> {
 
     repoFilter?: RepoFilter;
 
@@ -27,7 +28,7 @@ export interface ReviewerCommandDetails<PARAMS extends BaseEditorParameters> ext
 
 }
 
-function defaultDetails(name: string): ReviewerCommandDetails<BaseEditorParameters> {
+function defaultDetails(name: string): ReviewerCommandDetails<AllReposByDefaultParameters> {
     return {
         description: name,
         reviewRouter: issueRaisingReviewRouter,
@@ -35,18 +36,18 @@ function defaultDetails(name: string): ReviewerCommandDetails<BaseEditorParamete
 }
 
 /**
- * Create a handle function that reviews one or many repos, following BaseEditorParameters
+ * Create a handle function that reviews one or many repos, following AllReposByDefaultParameters
  * @param reviewerFactory function returning a reviewer instance for the appropriate parameters
  * @param {ParametersConstructor<PARAMS>} factory
  * @param {string} name
  * @param {string} details object allowing customization beyond reasonable defaults
  * @return {HandleCommand}
  */
-export function reviewerHandler<PARAMS extends BaseEditorParameters>(reviewerFactory: (params: PARAMS) => ProjectReviewer<PARAMS>,
-                                                                     factory: ParametersConstructor<PARAMS>,
-                                                                     name: string,
-                                                                     details: Partial<ReviewerCommandDetails<PARAMS>> = {}): HandleCommand {
-    const detailsToUse: ReviewerCommandDetails<BaseEditorParameters> = {
+export function reviewerHandler<PARAMS extends AllReposByDefaultParameters>(reviewerFactory: (params: PARAMS) => ProjectReviewer<PARAMS>,
+                                                                            factory: ParametersConstructor<PARAMS>,
+                                                                            name: string,
+                                                                            details: Partial<ReviewerCommandDetails<PARAMS>> = {}): HandleCommand {
+    const detailsToUse: ReviewerCommandDetails<AllReposByDefaultParameters> = {
         ...defaultDetails(name),
         ...details,
     };
@@ -60,9 +61,9 @@ export function reviewerHandler<PARAMS extends BaseEditorParameters>(reviewerFac
  * If owner and repo are required, review just one repo. Otherwise review all repos
  * in the present team
  */
-function handleReviewOneOrMany<PARAMS extends BaseEditorParameters>(reviewerFactory: (params: PARAMS) => ProjectReviewer<PARAMS>,
-                                                                    name: string,
-                                                                    details: ReviewerCommandDetails<PARAMS>): OnCommand<PARAMS> {
+function handleReviewOneOrMany<PARAMS extends GitHubParams>(reviewerFactory: (params: PARAMS) => ProjectReviewer<PARAMS>,
+                                                            name: string,
+                                                            details: ReviewerCommandDetails<PARAMS>): OnCommand<PARAMS> {
     return (ctx: HandlerContext, parameters: PARAMS) => {
         const credentials = {token: parameters.githubToken};
         const repoFinder: RepoFinder = (!!parameters.owner && !!parameters.repo) ?

--- a/src/operations/support/editorUtils.ts
+++ b/src/operations/support/editorUtils.ts
@@ -2,6 +2,7 @@ import { HandlerContext } from "../../HandlerContext";
 import { logger } from "../../internal/util/logger";
 import { GitProject } from "../../project/git/GitProject";
 import { Project } from "../../project/Project";
+import { RepoRef } from "../common/RepoId";
 import {
     BranchCommit,
     EditMode,
@@ -25,11 +26,11 @@ import { EditResult, ProjectEditor, successfulEdit } from "../edit/projectEditor
  * @param parameters to editor
  * @return EditResult instance that reports as to whether the project was actually edited
  */
-export function editRepo<P>(context: HandlerContext,
-                            repo: Project,
-                            editor: ProjectEditor<P>,
-                            ei: EditMode,
-                            parameters?: P): Promise<EditResult> {
+export function editRepo<P extends RepoRef>(context: HandlerContext,
+                                            repo: Project,
+                                            editor: ProjectEditor<P>,
+                                            ei: EditMode,
+                                            parameters?: P): Promise<EditResult> {
     if (isPullRequest(ei)) {
         return editProjectUsingPullRequest(context, repo as GitProject, editor, ei, parameters);
     } else if (isBranchCommit(ei)) {

--- a/test/operations/edit/editAllTest.ts
+++ b/test/operations/edit/editAllTest.ts
@@ -5,6 +5,8 @@ import * as assert from "power-assert";
 
 import { fromListRepoFinder, fromListRepoLoader } from "../../../src/operations/common/fromProjectList";
 import { GitHubRepoRef } from "../../../src/operations/common/GitHubRepoRef";
+import { AllReposByDefaultParameters } from "../../../src/operations/common/params/AllReposByDefaultParameters";
+import { AlwaysAskRepoParameters } from "../../../src/operations/common/params/AlwaysAskRepoParameters";
 import { editAll } from "../../../src/operations/edit/editAll";
 import { CustomExecutionEditMode } from "../../../src/operations/edit/editModes";
 import {
@@ -52,11 +54,13 @@ describe("editAll", () => {
     });
 
     it("should edit repo using params", done => {
-        class Params {
-            constructor(public name: string) {}
+        class VerySpecialParams extends AllReposByDefaultParameters {
+            constructor(public name: string) {
+                super();
+            }
         }
 
-        const editor: ProjectEditor<Params> = (p, ctx, params) => {
+        const editor: ProjectEditor<VerySpecialParams> = (p, ctx, params) => {
             p.addFileSync("thing", "1");
             assert(!!params.name);
             return Promise.resolve(successfulEdit(p, true));
@@ -77,7 +81,7 @@ describe("editAll", () => {
         };
 
         editAll(null, null, editor, cei,
-            new Params("antechinus"),
+            new VerySpecialParams("thing"),
             fromListRepoFinder(projects),
             p => true,
             fromListRepoLoader(projects))
@@ -111,7 +115,7 @@ describe("editAll", () => {
         };
 
         editAll(null, null, editor, cei,
-            {},
+            new AlwaysAskRepoParameters(),
             fromListRepoFinder(projects),
             p => true,
             fromListRepoLoader(projects))

--- a/test/operations/edit/editOneTest.ts
+++ b/test/operations/edit/editOneTest.ts
@@ -4,6 +4,7 @@ import * as assert from "power-assert";
 
 import { fromListRepoLoader } from "../../../src/operations/common/fromProjectList";
 import { GitHubRepoRef } from "../../../src/operations/common/GitHubRepoRef";
+import { AllReposByDefaultParameters } from "../../../src/operations/common/params/AllReposByDefaultParameters";
 import { editOne } from "../../../src/operations/edit/editAll";
 import { CustomExecutionEditMode } from "../../../src/operations/edit/editModes";
 import { InMemoryProject } from "../../../src/project/mem/InMemoryProject";
@@ -42,7 +43,7 @@ describe("editOne", () => {
                 assert.deepEqual(projectsEdited, projects);
                 return editResult.target.findFile("thing")
                     .then(f => f.getContent()
-                        .then( content => assert(content === "1")));
+                        .then(content => assert(content === "1")));
             }).then(done, done);
 
     });
@@ -69,7 +70,8 @@ describe("editOne", () => {
             },
         };
 
-        editOne( null, null, editor, cei, repoRef, {},
+        editOne(null, null, editor, cei, repoRef,
+            new AllReposByDefaultParameters(),
             fromListRepoLoader(projects))
             .then(editResult => {
                 assert(!editResult.edited);

--- a/test/operations/edit/editorHandlerTest.ts
+++ b/test/operations/edit/editorHandlerTest.ts
@@ -4,8 +4,8 @@ import * as assert from "power-assert";
 import { metadataFromInstance } from "../../../src/internal/metadata/metadataReading";
 import { CommandHandlerMetadata } from "../../../src/metadata/automationMetadata";
 import { fromListRepoFinder, fromListRepoLoader } from "../../../src/operations/common/fromProjectList";
+import { AllReposByDefaultParameters } from "../../../src/operations/common/params/AllReposByDefaultParameters";
 import { SimpleRepoId } from "../../../src/operations/common/RepoId";
-import { BaseEditorParameters } from "../../../src/operations/edit/BaseEditorParameters";
 import { editorHandler } from "../../../src/operations/edit/editorToCommand";
 import { InMemoryProject } from "../../../src/project/mem/InMemoryProject";
 import { BuildableAutomationServer } from "../../../src/server/BuildableAutomationServer";
@@ -15,7 +15,7 @@ describe("editorHandler", () => {
 
     it("should verify default no intent", () => {
         const h = editorHandler(() => p => Promise.resolve(p),
-            BaseEditorParameters,
+            AllReposByDefaultParameters,
             "editor");
         const chm = metadataFromInstance(h) as CommandHandlerMetadata;
         assert(!!chm.intent);
@@ -25,7 +25,7 @@ describe("editorHandler", () => {
         const description = "custom description";
         const intent = "this is a very long intent to type";
         const h = editorHandler(() => p => Promise.resolve(p),
-            BaseEditorParameters,
+            AllReposByDefaultParameters,
             "editor", {
                 description,
                 intent,
@@ -37,7 +37,7 @@ describe("editorHandler", () => {
 
     it("should register editor", done => {
         const h = editorHandler(() => p => Promise.resolve(p),
-            BaseEditorParameters,
+            AllReposByDefaultParameters,
             "editor");
         assert(metadataFromInstance(h).name === "editor");
         const s = new BuildableAutomationServer({name: "foobar", version: "1.0.0", teamIds: ["bar"], keywords: []});
@@ -51,7 +51,7 @@ describe("editorHandler", () => {
                 assert(params.owner === "foo");
                 return p => Promise.resolve(p);
             },
-            BaseEditorParameters,
+            AllReposByDefaultParameters,
             "editor", {
                 repoFinder: fromListRepoFinder([]),
             });
@@ -76,7 +76,7 @@ describe("editorHandler", () => {
                 assert(params.owner === "foo");
                 return p => p.addFile("Thing", "1");
             },
-            BaseEditorParameters,
+            AllReposByDefaultParameters,
             "editor", {
                 repoFinder: fromListRepoFinder([proj]),
                 repoLoader: () => fromListRepoLoader([proj]),


### PR DESCRIPTION
Allows choice of prompting for parameters, using mapped parameters or defaulting to all repos (former behavior of editor and reviewer handler functions.