### PR TITLE
add generator benchmark test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ npm-debug.log
 graphql.config.json
 git-info.json
 /.vscode
+
+/*-v8.log
+/profile.txt

--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
   "scripts": {
     "autostart": "npm-run-all --print-label --parallel watch:compile watch:server",
     "autotest": "supervisor --watch src,test --extensions ts --no-restart-on exit --quiet --exec npm -- test",
+    "benchmark": "mocha --prof --compilers ts:espower-typescript/guess \"test-perf/**/*Benchmark.ts\"; node --prof-process isolate-* > profile.txt",
     "build": "npm-run-all lint compile test test:api",
     "clean": "npm-run-all clean:js clean:build",
     "clean:build": "rimraf *-v8.log profile.txt build",

--- a/package.json
+++ b/package.json
@@ -117,7 +117,6 @@
   "scripts": {
     "autostart": "npm-run-all --print-label --parallel watch:compile watch:server",
     "autotest": "supervisor --watch src,test --extensions ts --no-restart-on exit --quiet --exec npm -- test",
-    "benchmark": "mocha --prof --compilers ts:espower-typescript/guess \"test-perf/**/*Benchmark.ts\"; node --prof-process isolate-* > profile.txt",
     "build": "npm-run-all lint compile test test:api",
     "clean": "npm-run-all clean:js clean:build",
     "clean:build": "rimraf *-v8.log profile.txt build",
@@ -137,6 +136,7 @@
     "start:server": "node $NODE_DEBUG_OPTION --trace-warnings --expose_gc --optimize_for_size --always_compact --max_old_space_size=256 build/src/start.client.js",
     "test": "mocha --require espower-typescript/guess --exit 'test/**/*.ts'",
     "test:api": "mocha --require espower-typescript/guess --exit 'test-api/**/*.ts'",
+    "test:benchmark": "mocha --prof --compilers ts:espower-typescript/guess \"test-perf/**/*.ts\"; node --prof-process isolate-* > profile.txt",
     "test:one": "mocha --require espower-typescript/guess \"test/**/${TEST:-*.ts}\"",
     "typedoc": "typedoc --mode modules --excludeExternals",
     "watch:compile": "tsc --project . --watch",

--- a/test-perf/GeneratorBenchmark.ts
+++ b/test-perf/GeneratorBenchmark.ts
@@ -30,15 +30,11 @@ describe("generator benchmark", () => {
                     assert.deepEqual(fileCount, numberOfSeedProjectFiles),
                 ).then(
                     () => {
-                        let lastGeneration: Promise<any>;
+                        const generationPromises: Array<Promise<any>> = [];
                         for (let i = 1; i < numberOfTimesToGenerate ; i++) {
-                            lastGeneration = generateFromSeed(seed, repoName);
+                            generationPromises.push(generateFromSeed(seed, repoName));
                         }
-                        if (lastGeneration) {
-                            lastGeneration.then(() => done());
-                        } else {
-                            done();
-                        }
+                        Promise.all(generationPromises).then(() => done());
                     },
                     e => done(e),
                 );

--- a/test-perf/GeneratorBenchmark.ts
+++ b/test-perf/GeneratorBenchmark.ts
@@ -1,0 +1,86 @@
+import "mocha";
+import * as assert from "power-assert";
+
+import { ActionResult, successOn } from "../src/action/ActionResult";
+import { GitHubRepoRef } from "../src/operations/common/GitHubRepoRef";
+import { ProjectOperationCredentials } from "../src/operations/common/ProjectOperationCredentials";
+import { RepoId } from "../src/operations/common/RepoId";
+import { generate, ProjectPersister } from "../src/operations/generate/generatorUtils";
+import { LocalProject } from "../src/project/local/LocalProject";
+import { NodeFsLocalProject } from "../src/project/local/NodeFsLocalProject";
+import { InMemoryProject } from "../src/project/mem/InMemoryProject";
+import { Project } from "../src/project/Project";
+
+describe("generator benchmark", () => {
+
+    const numberOfTimesToGenerate = 500;
+    const numberOfSeedProjectFiles = 100;
+    const numberOfLipsumInFile = 10;
+
+    it("should create a new GitHub repo using GenericGenerator", done => {
+        const repoName = "perfTestRepo";
+
+        const seed = constructProject(numberOfSeedProjectFiles, numberOfLipsumInFile);
+        generateFromSeed(seed, repoName)
+        .then(r => {
+            const result = r as ActionResult<LocalProject>;
+            NodeFsLocalProject.fromExistingDirectory(new GitHubRepoRef("atomist", repoName), result.target.baseDir)
+            .then(created => {
+                created.totalFileCount().then(fileCount =>
+                    assert.deepEqual(fileCount, numberOfSeedProjectFiles),
+                ).then(
+                    () => {
+                        let lastGeneration: Promise<any>;
+                        for (let i = 1; i < numberOfTimesToGenerate ; i++) {
+                            lastGeneration = generateFromSeed(seed, repoName);
+                        }
+                        if (lastGeneration) {
+                            lastGeneration.then(() => done());
+                        } else {
+                            done();
+                        }
+                    },
+                    e => done(e),
+                );
+            });
+        });
+    }).timeout(90000);
+});
+
+const generateFromSeed = (seed: Project, repoName: string): Promise<ActionResult<Project>> => {
+    const targetRepo = new GitHubRepoRef("atomist", repoName);
+    return generate(seed,
+        undefined,
+        {},
+        p => Promise.resolve(p),
+        MockProjectPersister,
+        targetRepo,
+    );
+};
+
+const MockProjectPersister: ProjectPersister<Project> =
+    (p: Project,
+     creds: ProjectOperationCredentials,
+     targetId: RepoId) => {
+        return Promise.resolve(successOn(p));
+    };
+
+const lipsum = `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et
+dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\n\n`;
+
+const constructProject = (fileCount: number, lipsumCountPerFile: number): Project => {
+    let fileContent: string = "";
+    for (let i = 0; i < lipsumCountPerFile ; i++) {
+        fileContent = fileContent.concat(lipsum);
+    }
+    const files = [];
+    for (let i = 0; i < fileCount ; i++) {
+        files.push({
+            path: "file" + i + ".txt",
+            content: fileContent,
+        });
+    }
+    return InMemoryProject.of(...files);
+};


### PR DESCRIPTION
It can be run with "npm run benchmark".
There are options to change the number of generator executions, number of files, and amount of file content.
No GitHub usage or tokens are needed. No shell cwd monkeying is required.
Generator source is an in memory project and the target is a local file based project.
I originally wanted to test GenericGenerator, but it does not return a useful result from the generator call that it makes, and it doesn't do anything extra that is relevant. So we are testing the generate method directly so that we can get a useful result back that will tell us the location of the tmp directory where the generated project is.
After the first generator execution we run a basic assert to sanity check that everything worked right, this does not happen on the rest of the executions which should work the same.