### PR TITLE
Remove handlers from scan glob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 -   Move cache directory to ~/.atomist/cache
 -   Generators now cache seed
 -   Several improvements to reviewer interfaces
+-   Scan all commands and events directories for command and event
+    handlers, respectively
 
 ### Fixed
 

--- a/src/scan.ts
+++ b/src/scan.ts
@@ -61,7 +61,7 @@ export function registerEvent(event: any) {
  * Optional glob patterns can be specified to narrow the search.
  */
 export function scanCommands(patterns: string | string[] =
-                                 [ "**/handlers/commands/**/*.js" ]): Array<Maker<HandleCommand>> {
+                                 [ "**/commands/**/*.js" ]): Array<Maker<HandleCommand>> {
     registry.start(true, false);
     // tslint:disable-next-line:variable-name
     const _patterns = toStringArray(patterns);
@@ -76,7 +76,7 @@ export function scanCommands(patterns: string | string[] =
  * Optional glob patterns can be specified to narrow the search.
  */
 export function scanEvents(patterns: string | string[] =
-                               [ "**/handlers/events/**/*.js" ]): Array<Maker<HandleEvent<any>>> {
+                               [ "**/events/**/*.js" ]): Array<Maker<HandleEvent<any>>> {
     registry.start(false, true);
     // tslint:disable-next-line:variable-name
     const _patterns = toStringArray(patterns);


### PR DESCRIPTION
Most projects do not have the handlers directory, using src/commands and
src/events instead.  Remove "handlers/" from the glob pattern to
scanning works either way.