### PR TITLE
move tests that expect a legitimate GitHub token to test-api

### DIFF
--- a/test-api/GitProjectRemoteTest.ts
+++ b/test-api/GitProjectRemoteTest.ts
@@ -1,0 +1,114 @@
+import axios from "axios";
+import "mocha";
+
+import * as assert from "power-assert";
+
+import * as _ from "lodash";
+import { GitHubDotComBase, GitHubRepoRef } from "../src/operations/common/GitHubRepoRef";
+import { GitCommandGitProject } from "../src/project/git/GitCommandGitProject";
+import { GitProject } from "../src/project/git/GitProject";
+import { TestRepositoryVisibility } from "../test/credentials";
+import {tempProject} from "../test/project/utils";
+import {Creds, GitHubToken} from "./gitHubTest";
+
+describe("GitProject remote", () => {
+
+    it("add a file, init and commit, then push to new remote repo", function(done) {
+        this.retries(5);
+
+        const p = tempProject();
+        p.addFileSync("Thing", "1");
+
+        const repo = `test-repo-2-${new Date().getTime()}`;
+
+        const gp: GitProject = GitCommandGitProject.fromProject(p, Creds);
+
+        getOwnerByToken().then(owner => gp.init()
+            .then(() => gp.createAndSetGitHubRemote(owner, repo, "Thing1", TestRepositoryVisibility))
+            .then(() => gp.commit("Added a Thing"))
+            .then(() => gp.push()
+                .then(() => deleteRepoIfExists({ owner, repo }).then(done)),
+        ).catch(() => deleteRepoIfExists({ owner, repo }).then(done)),
+        ).catch(done);
+
+    }).timeout(16000);
+
+    it("add a file, then PR push to remote repo", function(done) {
+        this.retries(1);
+
+        newRepo()
+            .then(ownerAndRepo => GitCommandGitProject.cloned(Creds,
+                new GitHubRepoRef(ownerAndRepo.owner, ownerAndRepo.repo))
+                .then(gp => {
+                    gp.addFileSync("Cat", "hat");
+                    const branch = "thing2";
+                    return gp.createBranch(branch)
+                        .then(() => gp.commit("Added a Thing"))
+                        .then(() => gp.push())
+                        .then(() => gp.raisePullRequest("Thing2", "Adds another character"))
+                        .then(() => deleteRepoIfExists(ownerAndRepo));
+                }).catch(err => deleteRepoIfExists(ownerAndRepo)
+                    .then(() => Promise.reject(err))))
+            .then(() => done(), done);
+
+    }).timeout(20000);
+
+});
+
+/**
+ * Create a new repo we can use for tests
+ * @return {Promise<{owner: string; repo: string}>}
+ */
+export function newRepo(): Promise<{ owner: string, repo: string }> {
+    const config = {
+        headers: {
+            Authorization: `token ${GitHubToken}`,
+        },
+    };
+    const name = `test-repo-${new Date().getTime()}`;
+    const description = "a thing";
+    const url = `${GitHubDotComBase}/user/repos`;
+    console.debug("Visibility is " + TestRepositoryVisibility);
+    return getOwnerByToken()
+        .then(owner => axios.post(url, {
+            name,
+            description,
+            private: TestRepositoryVisibility === "private",
+            auto_init: true,
+        }, config)
+            .then(() =>
+                ({ owner, repo: name })))
+        .catch(error => {
+            if (error.response.status === 422) {
+                throw new Error("Could not create repository. GitHub says: " +
+                    _.get(error, "response.data.message", "nothing"));
+            } else {
+                throw new Error("Could not create repo: " + error.message);
+            }
+        });
+}
+
+export function deleteRepoIfExists(ownerAndRepo: { owner: string, repo: string }): Promise<any> {
+    console.debug("Cleanup: deleting " + ownerAndRepo.repo);
+    const config = {
+        headers: {
+            Authorization: `token ${GitHubToken}`,
+        },
+    };
+    const url = `${GitHubDotComBase}/repos/${ownerAndRepo.owner}/${ownerAndRepo.repo}`;
+    return axios.delete(url, config)
+        .catch(err => {
+            console.error(`error deleting ${ownerAndRepo.repo}, ignoring. ${err.response.status}`);
+        });
+}
+
+function getOwnerByToken(): Promise<string> {
+    const config = {
+        headers: {
+            Authorization: `token ${GitHubToken}`,
+        },
+    };
+    return axios.get(`${GitHubDotComBase}/user`, config).then(response =>
+        response.data.login,
+    );
+}

--- a/test-api/editorUtilsWithGitHubPullRequestTest.ts
+++ b/test-api/editorUtilsWithGitHubPullRequestTest.ts
@@ -1,0 +1,46 @@
+import "mocha";
+import * as assert from "power-assert";
+
+import { GitHubRepoRef } from "../src/operations/common/GitHubRepoRef";
+import { PullRequest } from "../src/operations/edit/editModes";
+import { toEditor } from "../src/operations/edit/projectEditor";
+import { editProjectUsingBranch, editProjectUsingPullRequest } from "../src/operations/support/editorUtils";
+import { GitCommandGitProject } from "../src/project/git/GitCommandGitProject";
+import {Creds} from "./gitHubTest";
+import {deleteRepoIfExists, newRepo} from "./GitProjectRemoteTest";
+
+const EditorThatChangesProject = toEditor(p => p.addFile("thing", "thing"));
+
+describe("editorUtils tests with GitHub pull requests", () => {
+
+    it("creates branch with changes in simple editor", done => {
+        newRepo()
+            .then(repo => {
+                return GitCommandGitProject.cloned(Creds, new GitHubRepoRef(repo.owner, repo.repo))
+                    .then(p => {
+                        return editProjectUsingBranch(undefined, p, EditorThatChangesProject,
+                            new PullRequest("x", "y"))
+                            .then(er => {
+                                assert(er.edited);
+                            }).then(() => deleteRepoIfExists(repo));
+                    }).catch(err => deleteRepoIfExists(repo)
+                        .then(() => Promise.reject(err)));
+            }).then(() => done(), done);
+    }).timeout(15000);
+
+    it("creates PR with changes in simple editor", done => {
+        newRepo()
+            .then(repo => {
+                return GitCommandGitProject.cloned(Creds, new GitHubRepoRef(repo.owner, repo.repo))
+                    .then(p => {
+                        return editProjectUsingPullRequest(undefined, p, EditorThatChangesProject,
+                            new PullRequest("x", "y"))
+                            .then(er => {
+                                assert(er.edited);
+                            }).then(() => deleteRepoIfExists(repo));
+                    }).catch(err => deleteRepoIfExists(repo)
+                        .then(() => Promise.reject(err)));
+            }).then(() => done(), done);
+    }).timeout(15000);
+
+});

--- a/test-api/generatorEndToEndTest.ts
+++ b/test-api/generatorEndToEndTest.ts
@@ -6,17 +6,17 @@ import axios from "axios";
 
 import { SlackMessage } from "@atomist/slack-messages/SlackMessages";
 import * as fs from "fs";
-import { HandlerContext } from "../../../src/HandlerContext";
-import { GitHubDotComBase, GitHubRepoRef } from "../../../src/operations/common/GitHubRepoRef";
-import { BaseSeedDrivenGeneratorParameters } from "../../../src/operations/generate/BaseSeedDrivenGeneratorParameters";
-import { generate } from "../../../src/operations/generate/generatorUtils";
-import { GenericGenerator } from "../../../src/operations/generate/GenericGenerator";
-import { GitHubProjectPersister } from "../../../src/operations/generate/gitHubProjectPersister";
-import { GitCommandGitProject } from "../../../src/project/git/GitCommandGitProject";
-import { LocalProject } from "../../../src/project/local/LocalProject";
-import { Project } from "../../../src/project/Project";
-import { hasFile } from "../../../src/util/gitHub";
-import { GitHubToken } from "../../credentials";
+import { HandlerContext } from "../src/HandlerContext";
+import { GitHubDotComBase, GitHubRepoRef } from "../src/operations/common/GitHubRepoRef";
+import { BaseSeedDrivenGeneratorParameters } from "../src/operations/generate/BaseSeedDrivenGeneratorParameters";
+import { generate } from "../src/operations/generate/generatorUtils";
+import { GenericGenerator } from "../src/operations/generate/GenericGenerator";
+import { GitHubProjectPersister } from "../src/operations/generate/gitHubProjectPersister";
+import { GitCommandGitProject } from "../src/project/git/GitCommandGitProject";
+import { LocalProject } from "../src/project/local/LocalProject";
+import { Project } from "../src/project/Project";
+import { hasFile } from "../src/util/gitHub";
+import {GitHubToken} from "./gitHubTest";
 
 function tempRepoName() {
     return `test-repo-${new Date().getTime()}`;

--- a/test-api/gitHubTest.ts
+++ b/test-api/gitHubTest.ts
@@ -1,9 +1,16 @@
 import "mocha";
 
 import * as assert from "power-assert";
-import { GitHubRepoRef } from "../../../src/operations/common/GitHubRepoRef";
-import { createCommitComment, deepLink, fileContent, hasFile } from "../../../src/util/gitHub";
-import { GitHubToken } from "../../credentials";
+import { GitHubRepoRef } from "../src/operations/common/GitHubRepoRef";
+import { createCommitComment, deepLink, fileContent, hasFile } from "../src/util/gitHub";
+
+function barf(): string {
+    throw new Error("<please set GITHUB_TOKEN env variable>");
+}
+
+export const GitHubToken: string = process.env.GITHUB_TOKEN || barf();
+
+export const Creds = { token: GitHubToken };
 
 describe("gitHubUtils", () => {
 

--- a/test/credentials.ts
+++ b/test/credentials.ts
@@ -6,11 +6,7 @@ import { GitHubRepoRef } from "../src/operations/common/GitHubRepoRef";
 LoggingConfig.format = "cli";
 (logger as winston.LoggerInstance).level = process.env.LOG_LEVEL || "info";
 
-function barf(): string {
-    throw new Error("<please set GITHUB_TOKEN env variable>");
-}
-
-export const GitHubToken: string = process.env.GITHUB_TOKEN || barf();
+export const GitHubToken: string = "NOT_A_LEGIT_TOKEN";
 
 export const Creds = { token: GitHubToken };
 

--- a/test/operations/review/reviewerHandlerTest.ts
+++ b/test/operations/review/reviewerHandlerTest.ts
@@ -1,5 +1,6 @@
 import "mocha";
 
+import {SlackMessage} from "@atomist/slack-messages";
 import * as assert from "power-assert";
 import { fromListRepoFinder, fromListRepoLoader } from "../../../src/operations/common/fromProjectList";
 import { BaseEditorOrReviewerParameters } from "../../../src/operations/common/params/BaseEditorOrReviewerParameters";
@@ -7,7 +8,6 @@ import { SimpleRepoId } from "../../../src/operations/common/RepoId";
 import { reviewerHandler } from "../../../src/operations/review/reviewerToCommand";
 import { DefaultReviewComment, ReviewResult } from "../../../src/operations/review/ReviewResult";
 import { InMemoryProject } from "../../../src/project/mem/InMemoryProject";
-import { MockHandlerContext } from "../generate/generatorEndToEndTest";
 
 describe("reviewerHandler", () => {
 
@@ -37,3 +37,16 @@ describe("reviewerHandler", () => {
     });
 
 });
+
+const MockHandlerContext = {
+    messageClient: {
+        respond(msg: string | SlackMessage) {
+            return Promise.resolve();
+        },
+    },
+    graphClient: {
+        executeMutationFromFile(file: string, variables?: any): Promise<any> {
+            return Promise.resolve({createSlackChannel: [{id: "stts"}]});
+        },
+    },
+};

--- a/test/operations/support/editorUtilsTest.ts
+++ b/test/operations/support/editorUtilsTest.ts
@@ -1,19 +1,15 @@
 import "mocha";
 import * as assert from "power-assert";
 
-import { GitHubRepoRef } from "../../../src/operations/common/GitHubRepoRef";
 import { PullRequest } from "../../../src/operations/edit/editModes";
 import { toEditor } from "../../../src/operations/edit/projectEditor";
 import { editProjectUsingBranch, editProjectUsingPullRequest } from "../../../src/operations/support/editorUtils";
 import { GitCommandGitProject } from "../../../src/project/git/GitCommandGitProject";
-import { Creds, RepoThatExists } from "../../credentials";
-import { deleteRepoIfExists, newRepo } from "../../project/git/GitProjectTest";
+import {Creds, RepoThatExists} from "../../credentials";
 
 const NoOpEditor = toEditor(p => {
     return Promise.resolve(p);
 });
-
-const EditorThatChangesProject = toEditor(p => p.addFile("thing", "thing"));
 
 describe("editorUtils", () => {
 
@@ -29,21 +25,6 @@ describe("editorUtils", () => {
             }).catch(done);
     }).timeout(15000);
 
-    it("creates branch with changes in simple editor", done => {
-        newRepo()
-            .then(repo => {
-                return GitCommandGitProject.cloned(Creds, new GitHubRepoRef(repo.owner, repo.repo))
-                    .then(p => {
-                        return editProjectUsingBranch(undefined, p, EditorThatChangesProject,
-                            new PullRequest("x", "y"))
-                            .then(er => {
-                                assert(er.edited);
-                            }).then(() => deleteRepoIfExists(repo));
-                    }).catch(err => deleteRepoIfExists(repo)
-                        .then(() => Promise.reject(err)));
-            }).then(() => done(), done);
-    }).timeout(15000);
-
     it("doesn't attempt to create PR without changes", done => {
         GitCommandGitProject.cloned(Creds, RepoThatExists)
             .then(p => p.gitStatus().then(status => {
@@ -56,21 +37,6 @@ describe("editorUtils", () => {
                     .then(er => {
                         assert(!er.edited);
                     });
-            }).then(() => done(), done);
-    }).timeout(15000);
-
-    it("creates PR with changes in simple editor", done => {
-        newRepo()
-            .then(repo => {
-                return GitCommandGitProject.cloned(Creds, new GitHubRepoRef(repo.owner, repo.repo))
-                    .then(p => {
-                        return editProjectUsingPullRequest(undefined, p, EditorThatChangesProject,
-                            new PullRequest("x", "y"))
-                            .then(er => {
-                                assert(er.edited);
-                            }).then(() => deleteRepoIfExists(repo));
-                    }).catch(err => deleteRepoIfExists(repo)
-                        .then(() => Promise.reject(err)));
             }).then(() => done(), done);
     }).timeout(15000);
 


### PR DESCRIPTION
Changing these test to use mocks will take more work and may invalidate them.
there is still some interaction with GitHub in the unit tests that could be removed. But for now, any string without whitespace can be used as a token.