### PR TITLE
Add BitBucket generation support to generate function

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "start": "npm-run-all git:info start:server",
     "start:client": "node $NODE_DEBUG_OPTION build/src/start.client.js --open=true",
     "start:server": "node $NODE_DEBUG_OPTION --trace-warnings --expose_gc --optimize_for_size --always_compact --max_old_space_size=256 build/src/start.client.js",
-    "test": "mocha --require espower-typescript/guess --exit 'test/{*.ts,!(api|benchmark)/**/*.ts}'",
+    "test": "mocha --require espower-typescript/guess --exit 'test/{*.ts,!(api|benchmark|bitbucket-api)/**/*.ts}'",
     "test:api": "mocha --require espower-typescript/guess --exit 'test/api/**/*.ts'",
     "test:bitbucket-api": "mocha --require espower-typescript/guess --exit 'test/bitbucket-api/**/*.ts'",
     "test:benchmark": "npm-run-all test:benchmark:run test:benchmark:process clean:benchmark",

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "start": "npm-run-all git:info start:server",
     "start:client": "node $NODE_DEBUG_OPTION build/src/start.client.js --open=true",
     "start:server": "node $NODE_DEBUG_OPTION --trace-warnings --expose_gc --optimize_for_size --always_compact --max_old_space_size=256 build/src/start.client.js",
-    "test": "mocha --require espower-typescript/guess --exit 'test/{*.ts,!(api|benchmark|bitbucket-api)/**/*.ts}'",
+    "test": "mocha --require espower-typescript/guess --exit 'test/{*.ts,!(api|benchmark)/**/*.ts}'",
     "test:api": "mocha --require espower-typescript/guess --exit 'test/api/**/*.ts'",
     "test:bitbucket-api": "mocha --require espower-typescript/guess --exit 'test/bitbucket-api/**/*.ts'",
     "test:benchmark": "npm-run-all test:benchmark:run test:benchmark:process clean:benchmark",

--- a/src/action/actionOps.ts
+++ b/src/action/actionOps.ts
@@ -53,7 +53,7 @@ function toAction<T>(link: Chainable<T>): TAction<T> {
                         successOn(r) as ActionResult<T>;
                 });
         } catch (error) {
-            console.error("Failure: " + error.message);
+            // console.error("Failure: " + error.message);
             return Promise.resolve(failureOn(p, error, link));
         }
     };

--- a/src/operations/common/AbstractRemoteRepoRef.ts
+++ b/src/operations/common/AbstractRemoteRepoRef.ts
@@ -35,4 +35,5 @@ export abstract class AbstractRepoRef implements RemoteRepoRef {
     public abstract raisePullRequest(creds: ProjectOperationCredentials,
                                      title: string, body: string, head: string, base: string): Promise<ActionResult<this>>;
 
+    public abstract deleteRemote(creds: ProjectOperationCredentials): Promise<ActionResult<this>>;
 }

--- a/src/operations/common/GitHubRepoRef.ts
+++ b/src/operations/common/GitHubRepoRef.ts
@@ -15,6 +15,8 @@ export const GitHubDotComBase = "https://api.github.com";
  */
 export class GitHubRepoRef extends AbstractRepoRef {
 
+    public kind = "github";
+
     constructor(owner: string,
                 repo: string,
                 sha: string = "master",
@@ -86,7 +88,7 @@ export class GitHubRepoRef extends AbstractRepoRef {
 
 export function isGitHubRepoRef(rr: RepoRef): rr is GitHubRepoRef {
     const maybe = rr as GitHubRepoRef;
-    return maybe && !!maybe.apiBase;
+    return maybe && !!maybe.apiBase && maybe.kind === "github";
 }
 
 function headers(credentials: ProjectOperationCredentials): { headers: any } {

--- a/src/operations/common/GitHubRepoRef.ts
+++ b/src/operations/common/GitHubRepoRef.ts
@@ -32,15 +32,7 @@ export class GitHubRepoRef extends AbstractRepoRef {
     }
 
     public setUserConfig(credentials: ProjectOperationCredentials, project: Configurable): Promise<ActionResult<any>> {
-        if (!isTokenCredentials(credentials)) {
-            throw new Error("Only token auth supported");
-        }
-        const config = {
-            headers: {
-                Authorization: `token ${credentials.token}`,
-            },
-        };
-
+        const config = headers(credentials);
         return Promise.all([axios.get(`${this.apiBase}/user`, config),
             axios.get(`${this.apiBase}/user/emails`, config)])
             .then(results => {
@@ -63,14 +55,7 @@ export class GitHubRepoRef extends AbstractRepoRef {
     public raisePullRequest(credentials: ProjectOperationCredentials,
                             title: string, body: string, head: string, base: string): Promise<ActionResult<this>> {
         const url = `${this.apiBase}/repos/${this.owner}/${this.repo}/pulls`;
-        if (!isTokenCredentials(credentials)) {
-            throw new Error("Only token auth supported");
-        }
-        const config = {
-            headers: {
-                Authorization: `token ${credentials.token}`,
-            },
-        };
+        const config = headers(credentials);
         logger.debug(`Making request to '${url}' to raise PR`);
         return axios.post(url, {
             title,
@@ -90,9 +75,27 @@ export class GitHubRepoRef extends AbstractRepoRef {
                 return Promise.reject(err);
             });
     }
+
+    public deleteRemote(creds: ProjectOperationCredentials): Promise<ActionResult<this>> {
+        const url = `${this.apiBase}/repos/${this.owner}/${this.repo}`;
+        return axios.delete(url, headers(creds))
+            .then(r => successOn(this));
+    }
+
 }
 
 export function isGitHubRepoRef(rr: RepoRef): rr is GitHubRepoRef {
     const maybe = rr as GitHubRepoRef;
     return maybe && !!maybe.apiBase;
+}
+
+function headers(credentials: ProjectOperationCredentials): { headers: any } {
+    if (!isTokenCredentials(credentials)) {
+        throw new Error("Only token auth supported");
+    }
+    return {
+        headers: {
+            Authorization: `token ${credentials.token}`,
+        },
+    };
 }

--- a/src/operations/common/RemoteFactory.ts
+++ b/src/operations/common/RemoteFactory.ts
@@ -1,0 +1,12 @@
+
+import { GitHubRepoRef } from "./GitHubRepoRef";
+import { isRemoteRepoRef, RemoteRepoRef, RepoRef } from "./RepoId";
+
+/**
+ * Convention for resolving a local repo id to a RemoteRepoRef
+ * If it's already remote, simply return it.
+ */
+export type RemoteFactory = (rr: RepoRef) => RemoteRepoRef;
+
+export const GitHubDotComRemoteFactory = rr =>
+    isRemoteRepoRef(rr) ? rr : new GitHubRepoRef(rr.owner, rr.repo, rr.sha);

--- a/src/operations/common/RepoId.ts
+++ b/src/operations/common/RepoId.ts
@@ -73,6 +73,8 @@ export interface RemoteRepoRef extends RepoRef {
     raisePullRequest(credentials: ProjectOperationCredentials,
                      title: string, body: string, head: string, base: string): Promise<ActionResult<this>>;
 
+    deleteRemote(creds: ProjectOperationCredentials): Promise<ActionResult<this>>;
+
 }
 
 export function isRemoteRepoRef(r: RepoRef): r is RemoteRepoRef {

--- a/src/operations/generate/GenericGenerator.ts
+++ b/src/operations/generate/GenericGenerator.ts
@@ -10,7 +10,7 @@ import { RepoLoader } from "../common/repoLoader";
 import { AnyProjectEditor } from "../edit/projectEditor";
 import { BaseSeedDrivenGeneratorParameters } from "./BaseSeedDrivenGeneratorParameters";
 import { generate, ProjectPersister } from "./generatorUtils";
-import { GitHubProjectPersister } from "./gitHubProjectPersister";
+import { RemoteGitProjectPersister } from "./remoteGitProjectPersister";
 
 /**
  * Generator that uses external parameters. This decouples parameters from handle logic
@@ -31,7 +31,7 @@ export class GenericGenerator<P extends BaseSeedDrivenGeneratorParameters>
     constructor(private factory: ParametersConstructor<P>,
                 private editorFactory: (params: P, ctx: HandlerContext) => AnyProjectEditor<P>,
                 private redirecter: (r: RepoRef) => string = () => undefined,
-                private projectPersister: ProjectPersister = GitHubProjectPersister) {
+                private projectPersister: ProjectPersister = RemoteGitProjectPersister) {
     }
 
     public freshParametersInstance(): P {

--- a/src/operations/generate/generatorToCommand.ts
+++ b/src/operations/generate/generatorToCommand.ts
@@ -16,7 +16,7 @@ import { RepoLoader } from "../common/repoLoader";
 import { AnyProjectEditor } from "../edit/projectEditor";
 import { BaseSeedDrivenGeneratorParameters } from "./BaseSeedDrivenGeneratorParameters";
 import { generate, ProjectPersister } from "./generatorUtils";
-import { GitHubProjectPersister } from "./gitHubProjectPersister";
+import { RemoteGitProjectPersister } from "./remoteGitProjectPersister";
 import { addAtomistWebhook } from "./support/addAtomistWebhook";
 
 export type EditorFactory<P> = (params: P, ctx: HandlerContext) => AnyProjectEditor<P>;
@@ -36,7 +36,7 @@ function defaultDetails<P extends BaseSeedDrivenGeneratorParameters>(name: strin
         description: name,
         repoFinder: allReposInTeam(),
         repoLoader: (p: P) => defaultRepoLoader({ token: p.target.githubToken }, CachingDirectoryManager),
-        projectPersister: GitHubProjectPersister,
+        projectPersister: RemoteGitProjectPersister,
         redirecter: () => undefined,
     };
 }

--- a/src/operations/generate/gitHubProjectPersister.ts
+++ b/src/operations/generate/gitHubProjectPersister.ts
@@ -1,56 +1,9 @@
-import { ActionResult } from "../../action/ActionResult";
-import { logger } from "../../internal/util/logger";
-import { GitCommandGitProject } from "../../project/git/GitCommandGitProject";
 import { GitProject } from "../../project/git/GitProject";
-import { Project } from "../../project/Project";
-import { doWithRetry, RetryOptions } from "../../util/retry";
-import { GitHubRepoRef } from "../common/GitHubRepoRef";
-import { ProjectOperationCredentials } from "../common/ProjectOperationCredentials";
-import { isRemoteRepoRef, RepoId } from "../common/RepoId";
 import { ProjectPersister } from "./generatorUtils";
+import { RemoteGitProjectPersister } from "./remoteGitProjectPersister";
 
 /**
- * Persist project to GitHub, returning GitHub details. Use retry.
- * @param {Project} p project to persist
- * @param {ProjectOperationCredentials} creds
- * @param targetId id of target repo to create
- * @return {Promise<ActionResult<GitProject>>}
+ * Kept only for backward compatibility: Use RemoteGitProjectPersister
  */
 export const GitHubProjectPersister: ProjectPersister<GitProject> =
-    (p: Project,
-     creds: ProjectOperationCredentials,
-     targetId: RepoId) => {
-        // Default to github.com if we don't have more information
-        const gid = isRemoteRepoRef(targetId) ? targetId : new GitHubRepoRef(targetId.owner, targetId.repo);
-        const gp: GitProject =
-            GitCommandGitProject.fromProject(p, creds);
-        return gp.init()
-            .then(() => gp.configureFromRemote())
-            .then(() => {
-                logger.debug(`Creating new repo '${targetId.owner}/${targetId.repo}'`);
-                return gp.createAndSetRemote(
-                    gid,
-                    this.targetRepo, this.visibility)
-                    .catch(err => {
-                        return Promise.reject(new Error(`Unable to create new repo '${targetId.owner}/${targetId.repo}': ` +
-                            `Probably exists: ${err}`));
-                    });
-            })
-            .then(() => {
-                logger.debug(`Committing to local repo at '${gp.baseDir}'`);
-                return gp.commit("Initial commit from Atomist");
-            })
-            .then(() => push(gp));
-    };
-
-export function push(gp: GitProject, opts: Partial<RetryOptions> = {}): Promise<ActionResult<GitProject>> {
-    const retryOptions: RetryOptions = {
-        retries: 5,
-        factor: 3,
-        minTimeout: 1 * 500,
-        maxTimeout: 5 * 1000,
-        randomize: true,
-        ...opts,
-    };
-    return doWithRetry(() => gp.push(), `Pushing local repo at '${gp.baseDir}'`, retryOptions);
-}
+    RemoteGitProjectPersister;

--- a/src/operations/generate/remoteGitProjectPersister.ts
+++ b/src/operations/generate/remoteGitProjectPersister.ts
@@ -1,0 +1,58 @@
+import { ActionResult } from "../../action/ActionResult";
+import { logger } from "../../internal/util/logger";
+import { GitCommandGitProject } from "../../project/git/GitCommandGitProject";
+import { GitProject } from "../../project/git/GitProject";
+import { Project } from "../../project/Project";
+import { doWithRetry, RetryOptions } from "../../util/retry";
+import { GitHubRepoRef, isGitHubRepoRef } from "../common/GitHubRepoRef";
+import { ProjectOperationCredentials } from "../common/ProjectOperationCredentials";
+import { isRemoteRepoRef, RepoId } from "../common/RepoId";
+import { ProjectPersister } from "./generatorUtils";
+
+/**
+ * Persist project to GitHub or another remote, returning remote details. Use retry.
+ * @param {Project} p project to persist
+ * @param {ProjectOperationCredentials} creds
+ * @param targetId id of target repo to create
+ * @return {Promise<ActionResult<GitProject>>}
+ */
+export const RemoteGitProjectPersister: ProjectPersister<GitProject> =
+    (p: Project,
+     creds: ProjectOperationCredentials,
+     targetId: RepoId) => {
+        // Default to github.com if we don't have more information
+        const gid = isRemoteRepoRef(targetId) ? targetId : new GitHubRepoRef(targetId.owner, targetId.repo);
+        const gp: GitProject =
+            GitCommandGitProject.fromProject(p, creds);
+        return gp.init()
+            .then(() => {
+                return isGitHubRepoRef(gid) ? gp.configureFromRemote() : {};
+            })
+            .then(() => {
+                logger.debug(`Creating new repo '${targetId.owner}/${targetId.repo}'`);
+                return gp.createAndSetRemote(
+                    gid,
+                    this.targetRepo, this.visibility)
+                    .catch(err => {
+                        return Promise.reject(new Error(`Unable to create new repo '${targetId.owner}/${targetId.repo}': ` +
+                            `Probably exists: ${err}`));
+                    });
+            })
+            .then(() => {
+                logger.debug(`Committing to local repo at '${gp.baseDir}'`);
+                return gp.commit("Initial commit from Atomist");
+            })
+            .then(() => push(gp));
+    };
+
+export function push(gp: GitProject, opts: Partial<RetryOptions> = {}): Promise<ActionResult<GitProject>> {
+    const retryOptions: RetryOptions = {
+        retries: 5,
+        factor: 3,
+        minTimeout: 1 * 500,
+        maxTimeout: 5 * 1000,
+        randomize: true,
+        ...opts,
+    };
+    return doWithRetry(() => gp.push(), `Pushing local repo at '${gp.baseDir}'`, retryOptions);
+}

--- a/test/bitbucket-api/BitBucketGitTest.ts
+++ b/test/bitbucket-api/BitBucketGitTest.ts
@@ -28,7 +28,7 @@ describe("BitBucket support", () => {
                         .then(() => bp.push());
                 });
         });
-    }).timeout(15000);
+    }).timeout(20000);
 
     it("should clone and add file in new branch then raise PR", () => {
         return doWithNewRemote(bp => {
@@ -38,16 +38,15 @@ describe("BitBucket support", () => {
                 .then(() => bp.push())
                 .then(() => bp.raisePullRequest("Add a thing", "Dr Seuss is fun"));
         });
-    }).timeout(15000);
+    }).timeout(20000);
 
     it("add a file, init and commit, then push to new remote repo", () => {
         return doWithNewRemote(bp => {
             return bp.gitStatus();
         });
-    }).timeout(16000);
+    }).timeout(20000);
 
-})
-;
+});
 
 function doWithNewRemote(testAndVerify: (p: GitProject) => Promise<any>) {
     const p = tempProject();

--- a/test/bitbucket-api/BitBucketGitTest.ts
+++ b/test/bitbucket-api/BitBucketGitTest.ts
@@ -5,15 +5,15 @@ import { GitProject } from "../../src/project/git/GitProject";
 import { TestRepositoryVisibility } from "../credentials";
 import { tempProject } from "../project/utils";
 
-const BitBucketUser = process.env.ATLASSIAN_USER;
-const BitBucketPassword = process.env.ATLASSIAN_PASSWORD;
+export const BitBucketUser = process.env.ATLASSIAN_USER;
+export const BitBucketPassword = process.env.ATLASSIAN_PASSWORD;
 
-const bbCreds = { username: BitBucketUser, password: BitBucketPassword } as BasicAuthCredentials;
+export const BitBucketCredentials = { username: BitBucketUser, password: BitBucketPassword } as BasicAuthCredentials;
 
 describe("BitBucket support", () => {
 
     it("should clone", done => {
-        GitCommandGitProject.cloned(bbCreds,
+        GitCommandGitProject.cloned(BitBucketCredentials,
             new BitBucketRepoRef("jessitron", "poetry", "master"))
             .then(bp => bp.gitStatus())
             .then(() => done(), done);
@@ -54,7 +54,7 @@ function doWithNewRemote(testAndVerify: (p: GitProject) => Promise<any>) {
 
     const repo = `test-${new Date().getTime()}`;
 
-    const gp: GitProject = GitCommandGitProject.fromProject(p, bbCreds);
+    const gp: GitProject = GitCommandGitProject.fromProject(p, BitBucketCredentials);
     const owner = BitBucketUser;
 
     const bbid = new BitBucketRepoRef(owner, repo);
@@ -65,11 +65,11 @@ function doWithNewRemote(testAndVerify: (p: GitProject) => Promise<any>) {
             "Thing1", TestRepositoryVisibility))
         .then(() => gp.commit("Added a README"))
         .then(() => gp.push())
-        .then(() => GitCommandGitProject.cloned(bbCreds, bbid))
+        .then(() => GitCommandGitProject.cloned(BitBucketCredentials, bbid))
         .then(clonedp => {
             return testAndVerify(clonedp);
         })
-        .then(() => bbid.deleteRemote(bbCreds),
-            err => bbid.deleteRemote(bbCreds)
+        .then(() => bbid.deleteRemote(BitBucketCredentials),
+            err => bbid.deleteRemote(BitBucketCredentials)
                 .then(() => Promise.reject(new Error(err))));
 }

--- a/test/operations/generate/generatorToCommandTest.ts
+++ b/test/operations/generate/generatorToCommandTest.ts
@@ -3,16 +3,10 @@ import * as assert from "power-assert";
 
 import axios from "axios";
 import MockAdapter = require("axios-mock-adapter");
-
-import { successOn } from "../../../src/action/ActionResult";
-import { HandleCommand } from "../../../src/HandleCommand";
 import { HandlerContext } from "../../../src/HandlerContext";
 import { RedirectResult } from "../../../src/HandlerResult";
-import { SimpleRepoId } from "../../../src/operations/common/RepoId";
 import { BaseSeedDrivenGeneratorParameters } from "../../../src/operations/generate/BaseSeedDrivenGeneratorParameters";
 import { generatorHandler } from "../../../src/operations/generate/generatorToCommand";
-import { InMemoryProject } from "../../../src/project/mem/InMemoryProject";
-import { Project } from "../../../src/project/Project";
 import { mockProjectPersister } from "./generatorUtilsTest";
 
 describe("generatorToCommand", () => {
@@ -73,7 +67,7 @@ describe("generatorToCommand", () => {
             assert(postedHook, "posted Atomist webhook to api.github.com");
             assert(responseMessage === "Successfully created new project");
         }).then(() => done(), done);
-    });
+    }).timeout(15000);
 
     it("does not add Atomist webhook to repo", done => {
         const owner = "metric";
@@ -129,6 +123,6 @@ describe("generatorToCommand", () => {
             assert(postedHook === false, "posted Atomist webhook when it should not have");
             assert(responseMessage === "Successfully created new project");
         }).then(() => done(), done);
-    });
+    }).timeout(10000);
 
 });


### PR DESCRIPTION
- Introduce `deleteRemote` method and implement for GitHub for consistency
- Add BitBucket generation support
- Rename `githubProjectPersister` `gitRemoteProjectPersister` while preserving backward compatibility
- Project persister no longer GitHub specific
- Remove code duplication in header creation in `GitHubRepoRef`
- Suppress console output

Please preserve commit history.