### PR TITLE
Hide ProjectOperationCredentials type in GitHubTargetsParams

### DIFF
--- a/src/operations/common/params/BaseEditorOrReviewerParameters.ts
+++ b/src/operations/common/params/BaseEditorOrReviewerParameters.ts
@@ -1,6 +1,6 @@
 import { Parameters } from "../../../decorators";
-import { GitHubTargetsParams } from "./GitHubTargetsParams";
 import { MappedRepoParameters } from "./MappedRepoParameters";
+import { TargetsParams } from "./TargetsParams";
 
 /**
  * Contract for all editor or reviewer parameters
@@ -10,7 +10,7 @@ export interface EditorOrReviewerParameters {
     /**
      * Describe target repos
      */
-    targets: GitHubTargetsParams;
+    targets: TargetsParams;
 }
 
 /**
@@ -19,5 +19,5 @@ export interface EditorOrReviewerParameters {
 @Parameters()
 export class BaseEditorOrReviewerParameters implements EditorOrReviewerParameters {
 
-    constructor(public targets: GitHubTargetsParams = new MappedRepoParameters()) {}
+    constructor(public targets: TargetsParams = new MappedRepoParameters()) {}
 }

--- a/src/operations/common/params/GitHubTargetsParams.ts
+++ b/src/operations/common/params/GitHubTargetsParams.ts
@@ -1,28 +1,20 @@
 import { Parameters, Secret, Secrets } from "../../../decorators";
-import { GitHubRepoRef } from "../GitHubRepoRef";
-import { RepoRef } from "../RepoId";
-import { GitHubNameRegExp } from "./gitHubPatterns";
 
+import { GitHubRepoRef } from "../GitHubRepoRef";
+import { ProjectOperationCredentials } from "../ProjectOperationCredentials";
 import { RepoFilter } from "../repoFilter";
+import { TargetsParams } from "./TargetsParams";
 
 /**
  * Base parameters for working with GitHub repo(s).
  * Allows use of regex.
  */
 @Parameters()
-export abstract class GitHubTargetsParams {
+export abstract class GitHubTargetsParams extends TargetsParams {
 
-    @Secret(Secrets.userToken(["repo", "user"]))
-    public githubToken: string;
-
-    public abstract owner;
-
-    /**
-     * Repo name. May be a repo name or a regex.
-     */
-    public abstract repo;
-
-    public abstract sha;
+    get credentials(): ProjectOperationCredentials {
+        return { token: this.githubToken };
+    }
 
     /**
      * Return a single RepoRef or undefined if we're not identifying a single repo
@@ -34,24 +26,7 @@ export abstract class GitHubTargetsParams {
             undefined;
     }
 
-    get usesRegex() {
-        return !!this.repo && !GitHubNameRegExp.pattern.test(this.repo);
-    }
-
-    /**
-     * If we're not tied to a single repo ref, test this RepoRef
-     * @param {RepoRef} rr
-     * @return {boolean}
-     */
-    public test: RepoFilter = rr => {
-        if (this.repoRef) {
-            const my = this.repoRef;
-            return my.owner === rr.owner && my.repo === rr.repo;
-        }
-        if (this.usesRegex) {
-            return new RegExp(this.repo).test(rr.repo);
-        }
-        return false;
-    }
+    @Secret(Secrets.userToken(["repo", "user"]))
+    private githubToken: string;
 
 }

--- a/src/operations/common/params/TargetsParams.ts
+++ b/src/operations/common/params/TargetsParams.ts
@@ -1,0 +1,50 @@
+import { RemoteRepoRef, RepoRef } from "../RepoId";
+import { GitHubNameRegExp } from "./gitHubPatterns";
+
+import { ProjectOperationCredentials } from "../ProjectOperationCredentials";
+import { RepoFilter } from "../repoFilter";
+
+/**
+ * Base parameters for working with repo(s).
+ * Allows use of regex.
+ */
+export abstract class TargetsParams {
+
+    public abstract owner;
+
+    /**
+     * Repo name. May be a repo name or a regex.
+     */
+    public abstract repo;
+
+    public abstract sha;
+
+    public abstract credentials: ProjectOperationCredentials;
+
+    /**
+     * Return a single RepoRef or undefined if we're not identifying a single repo
+     * @return {RepoRef}
+     */
+    public abstract repoRef: RemoteRepoRef;
+
+    get usesRegex() {
+        return !!this.repo && !GitHubNameRegExp.pattern.test(this.repo);
+    }
+
+    /**
+     * If we're not tied to a single repo ref, test this RepoRef
+     * @param {RepoRef} rr
+     * @return {boolean}
+     */
+    public test: RepoFilter = rr => {
+        if (this.repoRef) {
+            const my = this.repoRef;
+            return my.owner === rr.owner && my.repo === rr.repo;
+        }
+        if (this.usesRegex) {
+            return new RegExp(this.repo).test(rr.repo);
+        }
+        return false;
+    }
+
+}

--- a/src/operations/edit/editorToCommand.ts
+++ b/src/operations/edit/editorToCommand.ts
@@ -60,7 +60,7 @@ export function editorHandler<PARAMS extends EditorOrReviewerParameters>(pe: (pa
 function handleEditOneOrMany<PARAMS extends BaseEditorOrReviewerParameters>(pe: (params: PARAMS) => AnyProjectEditor,
                                                                             details: EditorCommandDetails): OnCommand<PARAMS> {
     return (ctx: HandlerContext, parameters: PARAMS) => {
-        const credentials = {token: parameters.targets.githubToken};
+        const credentials = parameters.targets.credentials;
         if (!!parameters.targets.repoRef) {
             return editOne(ctx, credentials,
                 pe(parameters),

--- a/src/operations/review/issueRaisingReviewRouter.ts
+++ b/src/operations/review/issueRaisingReviewRouter.ts
@@ -3,6 +3,7 @@ import { failureOn, successOn } from "../../action/ActionResult";
 import { deepLink, Issue, raiseIssue } from "../../util/gitHub";
 import { GitHubRepoRef, isGitHubRepoRef } from "../common/GitHubRepoRef";
 import { EditorOrReviewerParameters } from "../common/params/BaseEditorOrReviewerParameters";
+import { TokenCredentials } from "../common/ProjectOperationCredentials";
 import { ReviewRouter } from "./reviewerToCommand";
 import { ProjectReview, ReviewComment } from "./ReviewResult";
 
@@ -17,7 +18,7 @@ export const issueRaisingReviewRouter: ReviewRouter<EditorOrReviewerParameters> 
     (pr: ProjectReview, params: EditorOrReviewerParameters, name: string) => {
         if (isGitHubRepoRef(pr.repoId)) {
             const issue = toIssue(pr, name);
-            return raiseIssue(params.targets.githubToken, pr.repoId, issue)
+            return raiseIssue((params.targets.credentials as TokenCredentials).token, pr.repoId, issue)
                 .then(ap => successOn(pr.repoId));
         } else {
             return Promise.resolve(failureOn(pr.repoId, new Error(`Not a GitHub Repo: ${JSON.stringify(pr.repoId)}`)));

--- a/src/operations/review/reviewerToCommand.ts
+++ b/src/operations/review/reviewerToCommand.ts
@@ -66,11 +66,10 @@ function handleReviewOneOrMany<PARAMS extends EditorOrReviewerParameters>(review
                                                                           name: string,
                                                                           details: ReviewerCommandDetails<PARAMS>): OnCommand<PARAMS> {
     return (ctx: HandlerContext, parameters: PARAMS) => {
-        const credentials = {token: parameters.targets.githubToken};
         const repoFinder: RepoFinder = parameters.targets.repoRef ?
             () => Promise.resolve([parameters.targets.repoRef]) :
             details.repoFinder;
-        return reviewAll(ctx, credentials, reviewerFactory(parameters), parameters,
+        return reviewAll(ctx, parameters.targets.credentials, reviewerFactory(parameters), parameters,
             repoFinder,
             andFilter(parameters.targets.test, details.repoFilter),
             !!details.repoLoader ? details.repoLoader(parameters) : undefined)

--- a/src/operations/tagger/taggerHandler.ts
+++ b/src/operations/tagger/taggerHandler.ts
@@ -60,11 +60,10 @@ function tagOneOrMany<PARAMS extends EditorOrReviewerParameters>(tagger: Tagger<
                                                                  name: string,
                                                                  details: TaggerCommandDetails<PARAMS>): OnCommand<PARAMS> {
     return (ctx: HandlerContext, parameters: PARAMS) => {
-        const credentials = {token: parameters.targets.githubToken};
         const repoFinder: RepoFinder = parameters.targets.repoRef ?
             () => Promise.resolve([parameters.targets.repoRef]) :
             details.repoFinder;
-        return tagAll(ctx, credentials, tagger, parameters,
+        return tagAll(ctx, parameters.targets.credentials, tagger, parameters,
             repoFinder,
             andFilter(parameters.targets.test, details.repoFilter),
             !!details.repoLoader ? details.repoLoader(parameters) : undefined)


### PR DESCRIPTION
Decouples reviewer and editor command support from GitHub.