### PR TITLE
fewer user/email calls

### DIFF
--- a/src/operations/common/GitHubRepoRef.ts
+++ b/src/operations/common/GitHubRepoRef.ts
@@ -54,7 +54,7 @@ export class GitHubRepoRef extends AbstractRepoRef {
                             .then(emailsResult => {
                                 email = emailsResult.data.find(e => e.primary === true).email || "bot@atomist.com";
                                 return project.setUserConfig("Atomist Bot", "bot@atomist.com");
-                            })
+                            });
                     }
                 }).catch(() => project.setUserConfig("Atomist Bot", "bot@atomist.com"));
         }

--- a/src/operations/common/GitHubRepoRef.ts
+++ b/src/operations/common/GitHubRepoRef.ts
@@ -33,16 +33,19 @@ export class GitHubRepoRef extends AbstractRepoRef {
             .then(() => successOn(this));
     }
 
-    public setUserConfig(credentials: ProjectOperationCredentials, project: Configurable): Promise<ActionResult<any>> {
+    public setUserConfig(credentials: ProjectOperationCredentials,
+                         project: Configurable): Promise<ActionResult<any>> {
         const config = headers(credentials);
-        return Promise.all([axios.get(`${this.apiBase}/user`, config),
-            axios.get(`${this.apiBase}/user/emails`, config)])
+        return Promise.all(
+            [axios.get(`${this.apiBase}/user`, config),
+                axios.get(`${this.apiBase}/user/emails`, config)])
             .then(results => {
-                const name = results[0].data.name;
-                let email = results[0].data.email;
+                const [userResult, emailsResult] = results;
+                const name = userResult.data.name;
+                let email = userResult.data.email;
 
                 if (!email) {
-                    email = results[1].data.find(e => e.primary === true).email;
+                    email = emailsResult.data.find(e => e.primary === true).email;
                 }
 
                 if (name && email) {


### PR DESCRIPTION
i want to have the ability to pass in a user/email, like from the graph.

The real problem here happens when someone is running the automation locally and it's using their local token which they generated themselves and didn't check "user/emails" permission. If we can pass in the name/email, then we can attribute the commit correctly even without having the token for the user who triggered the editor.