### PR TITLE
Handle non-git automation clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 [Unreleased]: https://github.com/atomist/automation-client-ts/compare/0.5.2...HEAD
 
+### Changed
+
+-   Trying to get Git information on a non-git project will now return
+    empty values instead of failing [#131][131]
+
+[131]: https://github.com/atomist/automation-client-ts/issues/131
+
 ## [0.5.2][] - 2017-12-4
 
 [0.5.2]: https://github.com/atomist/automation-client-ts/compare/0.5.0...0.5.2

--- a/src/internal/env/gitInfo.ts
+++ b/src/internal/env/gitInfo.ts
@@ -1,21 +1,87 @@
+import * as fs from "fs-extra";
+import * as path from "path";
+
 import { runCommand } from "../../action/cli/commandLine";
+import { logger } from "../util/logger";
 
+/**
+ * Return Git remote origin URL, branch, and sha for provided
+ * directory.  If provided directory is not a Git repository, empty
+ * strings will be returned for the repository, branch, and sha.
+ *
+ * @param directory path to local Git repository
+ * @return Git URL, branch, and sha
+ */
 export function obtainGitInfo(directory: string): Promise<GitInformation> {
-
-    return Promise.all([
-        runCommand("git rev-parse HEAD", { cwd: directory }),
-        runCommand("git rev-parse --abbrev-ref HEAD", { cwd: directory }),
-        runCommand("git remote get-url origin", { cwd: directory }),
-    ])
-        .then(results => {
-            return Promise.resolve({
-                sha: results[0].stdout.trim(),
-                branch: results[1].stdout.trim(),
-                repository: results[2].stdout.trim(),
-            });
+    const gitInfo: GitInformation = {
+        sha: "",
+        branch: "",
+        repository: "",
+    };
+    const gitPath = path.join(directory, ".git");
+    const headPath = path.join(gitPath, "HEAD");
+    const refsPath = path.join(gitPath, "refs", "heads");
+    const configPath = path.join(gitPath, "config");
+    return fs.readFile(headPath)
+        .then(headLine => {
+            const head = headLine.toString().trim();
+            const refHead = "ref: refs/heads/";
+            if (head.indexOf(refHead) === 0) {
+                const branch = head.replace(refHead, "");
+                if (!branch) {
+                    throw new Error(`failed to get branch from ${headPath}: ${head}`);
+                }
+                gitInfo.branch = branch;
+                const branchPath = path.join(refsPath, branch);
+                return fs.readFile(branchPath)
+                    .then(ref => {
+                        const sha = ref.toString().trim();
+                        if (!sha) {
+                            throw new Error(`failed to get SHA from ${branchPath}`);
+                        }
+                        gitInfo.sha = sha;
+                    });
+            } else {
+                gitInfo.sha = head;
+                gitInfo.branch = head;
+            }
+        })
+        .then(() => {
+            return fs.readFile(configPath)
+                .then(config => {
+                    const configLines = config.toString().split("\n");
+                    for (let i = 0; i < configLines.length; i++) {
+                        if (/^\[remote "origin"\]$/.test(configLines[i])) {
+                            for (let j = i + 1; i < configLines.length; j++) {
+                                if (/^\s+url\s*=/.test(configLines[j])) {
+                                    const url = configLines[j].replace(/.*?=\s*/, "");
+                                    if (!url) {
+                                        continue;
+                                    }
+                                    gitInfo.repository = url;
+                                    i = configLines.length;
+                                    break;
+                                } else if (/^\S/.test(configLines[j])) {
+                                    i = j;
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                    if (!gitInfo.repository) {
+                        throw new Error(`failed to get remote origin URL from ${configPath}`);
+                    }
+                });
+        })
+        .then(() => Promise.resolve(gitInfo), err => {
+            logger.info(`failed to fully populate git information: ${err.message}`);
+            return Promise.resolve(gitInfo);
         });
 }
 
+/*
+ * Information about current Git commit and remote.
+ */
 export interface GitInformation {
     sha: string;
     branch: string;

--- a/test/internal/env/gitInfoTest.ts
+++ b/test/internal/env/gitInfoTest.ts
@@ -1,13 +1,16 @@
-import * as appRoot from "app-root-path";
-import * as stringify from "json-stringify-safe";
 import "mocha";
 import * as assert from "power-assert";
+
+import * as appRoot from "app-root-path";
+import * as fs from "fs-extra";
+import * as stringify from "json-stringify-safe";
 import * as tmp from "tmp-promise";
+
 import { obtainGitInfo } from "../../../src/internal/env/gitInfo";
 
 describe("gitInfo", () => {
 
-    it("verify correct git info", done => {
+    it("verify git info", done => {
         obtainGitInfo(appRoot.path)
             .then(info => {
                 assert(info.branch);
@@ -17,14 +20,109 @@ describe("gitInfo", () => {
 
     });
 
-    it("verify git info fails for non-git repo path", done => {
+    const repo = "git@github.com:atomist/prince-automation.git";
+    const gitConfig = `[core]
+	repositoryformatversion = 0
+	filemode = true
+	bare = false
+	logallrefupdates = true
+	ignorecase = true
+	precomposeunicode = true
+[remote "origin"]
+	url = ${repo}
+	fetch = +refs/heads/*:refs/remotes/origin/*
+[branch "master"]
+	remote = origin
+	merge = refs/heads/master
+	pushRemote = origin
+[branch "update-build"]
+	pushRemote = origin
+`;
+
+    it("verify correct git info", done => {
+        tmp.dir({ unsafeCleanup: true })
+            .then(dir => {
+                const gitDir = dir.path + "/.git";
+                const gitRefsDir = gitDir + "/refs/heads";
+                fs.ensureDirSync(gitRefsDir);
+                fs.ensureDirSync(gitDir + "/refs/tags");
+                fs.ensureDirSync(gitDir + "/objects/info");
+                fs.ensureDirSync(gitDir + "/objects/pack");
+                const branch = "git-info-131";
+                const sha = "7629f65faaf63919041bb703962cac59a7c415bc";
+                fs.writeFileSync(gitDir + "/config", gitConfig);
+                fs.writeFileSync(gitDir + "/HEAD", `ref: refs/heads/${branch}\n`);
+                fs.writeFileSync(`${gitRefsDir}/${branch}`, `${sha}\n`);
+                return obtainGitInfo(dir.path)
+                    .then(info => {
+                        assert(info.branch === branch);
+                        assert(info.repository === repo);
+                        assert(info.sha === sha);
+                    })
+                    .then(() => dir.cleanup());
+            }).then(() => done(), done);
+
+    });
+
+    it("verify correct git info for branch with /", done => {
+        tmp.dir({ unsafeCleanup: true })
+            .then(dir => {
+                const gitDir = dir.path + "/.git";
+                const gitRefsDir = gitDir + "/refs/heads";
+                fs.ensureDirSync(gitRefsDir + "/nortissej");
+                fs.ensureDirSync(gitDir + "/refs/tags");
+                fs.ensureDirSync(gitDir + "/objects/info");
+                fs.ensureDirSync(gitDir + "/objects/pack");
+                const branch = "nortissej/git-info-131";
+                const sha = "7629f65faaf63919041bb703962cac59a7c415bc";
+                fs.writeFileSync(gitDir + "/config", gitConfig);
+                fs.writeFileSync(gitDir + "/HEAD", `ref: refs/heads/${branch}\n`);
+                fs.writeFileSync(`${gitRefsDir}/${branch}`, `${sha}\n`);
+                return obtainGitInfo(dir.path)
+                    .then(info => {
+                        assert(info.branch === branch);
+                        assert(info.repository === repo);
+                        assert(info.sha === sha);
+                    })
+                    .then(() => dir.cleanup());
+            }).then(() => done(), done);
+
+    });
+
+    it("verify correct git info for SHA checkout", done => {
+        tmp.dir({ unsafeCleanup: true })
+            .then(dir => {
+                const gitDir = dir.path + "/.git";
+                const gitRefsDir = gitDir + "/refs/heads";
+                fs.ensureDirSync(gitRefsDir);
+                fs.ensureDirSync(gitDir + "/refs/tags");
+                fs.ensureDirSync(gitDir + "/objects/info");
+                fs.ensureDirSync(gitDir + "/objects/pack");
+                const sha = "7629f65faaf63919041bb703962cac59a7c415bc";
+                fs.writeFileSync(gitDir + "/config", gitConfig);
+                fs.writeFileSync(gitDir + "/HEAD", `${sha}\n`);
+                return obtainGitInfo(dir.path)
+                    .then(info => {
+                        assert(info.branch === sha);
+                        assert(info.repository === repo);
+                        assert(info.sha === sha);
+                    })
+                    .then(() => dir.cleanup());
+            }).then(() => done(), done);
+
+    });
+
+    it("verify git info empty for non-git repo path", done => {
         tmp.dir({ unsafeCleanup: true })
             .then(dir => {
                 return obtainGitInfo(dir.path)
-                    .then(() => assert(false, "succeeded"), err => assert(true, `failed: ${err.message}`))
+                    .then(info => {
+                        assert(info.branch === "");
+                        assert(info.repository === "");
+                        assert(info.sha === "");
+                    })
                     .then(() => dir.cleanup());
-            })
-            .then(() => done(), done);
+            }).then(() => done(), done);
 
     });
 


### PR DESCRIPTION
Gracefully handle non-Git repositories when determining Git
information.  Rather that rely on git binary, extract Git information
directly.

Resolves #131