### PR TITLE
Tiny PR to hide ProjectOperationCredentials in generation

### DIFF
--- a/src/operations/common/params/Credentialed.ts
+++ b/src/operations/common/params/Credentialed.ts
@@ -1,0 +1,12 @@
+
+import { ProjectOperationCredentials } from "../ProjectOperationCredentials";
+
+/**
+ * Implemented by parameters that carry ProjectOperationCredentials.
+ * Hides whether they are tokens etc.
+ */
+export interface Credentialed {
+
+    credentials: ProjectOperationCredentials;
+
+}

--- a/src/operations/common/params/TargetsParams.ts
+++ b/src/operations/common/params/TargetsParams.ts
@@ -3,13 +3,14 @@ import { GitHubNameRegExp } from "./gitHubPatterns";
 
 import { ProjectOperationCredentials } from "../ProjectOperationCredentials";
 import { RepoFilter } from "../repoFilter";
+import { Credentialed } from "./Credentialed";
 import { RemoteLocator } from "./RemoteLocator";
 
 /**
  * Base parameters for working with repo(s).
  * Allows use of regex.
  */
-export abstract class TargetsParams implements RemoteLocator {
+export abstract class TargetsParams implements Credentialed, RemoteLocator {
 
     public abstract owner;
 

--- a/src/operations/generate/NewRepoCreationParameters.ts
+++ b/src/operations/generate/NewRepoCreationParameters.ts
@@ -1,13 +1,15 @@
 import { MappedParameter, MappedParameters, Parameter, Secret, Secrets } from "../../decorators";
 import { GitHubRepoRef } from "../common/GitHubRepoRef";
+import { Credentialed } from "../common/params/Credentialed";
 import { GitHubNameRegExp } from "../common/params/gitHubPatterns";
 import { RemoteLocator } from "../common/params/RemoteLocator";
+import { ProjectOperationCredentials } from "../common/ProjectOperationCredentials";
 import { RemoteRepoRef, RepoId } from "../common/RepoId";
 
 /**
  * Parameters common to all generators that create new repositories
  */
-export class NewRepoCreationParameters implements RepoId, RemoteLocator {
+export class NewRepoCreationParameters implements Credentialed, RepoId, RemoteLocator {
 
     @Secret(Secrets.userToken(["repo", "user:email", "read:user"]))
     public githubToken;
@@ -47,6 +49,10 @@ export class NewRepoCreationParameters implements RepoId, RemoteLocator {
         required: false,
     })
     public visibility: "public" | "private" = "public";
+
+    get credentials(): ProjectOperationCredentials {
+        return { token: this.githubToken };
+    }
 
     /**
      * Return a single RepoRef or undefined if we're not identifying a single repo

--- a/src/operations/generate/generatorToCommand.ts
+++ b/src/operations/generate/generatorToCommand.ts
@@ -84,7 +84,7 @@ function handle<P extends BaseSeedDrivenGeneratorParameters>(ctx: HandlerContext
                             .then(() => p);
                     }),
                 ctx,
-                { token: params.target.githubToken },
+                params.target.credentials,
                 editorFactory(params, ctx),
                 details.projectPersister,
                 // IT'S A REPO ID


### PR DESCRIPTION
Backward compatible.