### PR TITLE
Decouple generator parameters from GitHub.com

### DIFF
--- a/src/operations/common/params/GitHubSourceRepoParameters.ts
+++ b/src/operations/common/params/GitHubSourceRepoParameters.ts
@@ -1,0 +1,12 @@
+import { GitHubRepoRef } from "../GitHubRepoRef";
+import { SourceRepoParameters } from "./SourceRepoParameters";
+
+export class GitHubSourceRepoParameters extends SourceRepoParameters {
+
+    get repoRef() {
+        return (!!this.owner && !!this.repo) ?
+            new GitHubRepoRef(this.owner, this.repo) :
+            undefined;
+    }
+
+}

--- a/src/operations/common/params/SourceRepoParameters.ts
+++ b/src/operations/common/params/SourceRepoParameters.ts
@@ -1,5 +1,4 @@
 import { Parameter } from "../../../decorators";
-import { GitHubRepoRef } from "../GitHubRepoRef";
 import { RemoteRepoRef, RepoRef } from "../RepoId";
 import { GitBranchRegExp, GitHubNameRegExp } from "./gitHubPatterns";
 import { RemoteLocator } from "./RemoteLocator";
@@ -8,7 +7,7 @@ import { RemoteLocator } from "./RemoteLocator";
  * Parameters common to anything that works with a single source repo,
  * such as a seed driven generator
  */
-export class SourceRepoParameters implements RepoRef, RemoteLocator {
+export abstract class SourceRepoParameters implements RepoRef, RemoteLocator {
 
     @Parameter({
         pattern: GitHubNameRegExp.pattern,
@@ -52,10 +51,6 @@ export class SourceRepoParameters implements RepoRef, RemoteLocator {
      * to return any kind of repo
      * @return {RepoRef}
      */
-    get repoRef(): RemoteRepoRef {
-        return (!!this.owner && !!this.repo) ?
-            new GitHubRepoRef(this.owner, this.repo) :
-            undefined;
-    }
+    public abstract repoRef: RemoteRepoRef;
 
 }

--- a/src/operations/generate/BaseSeedDrivenGeneratorParameters.ts
+++ b/src/operations/generate/BaseSeedDrivenGeneratorParameters.ts
@@ -1,16 +1,15 @@
 import { MappedParameter, MappedParameters, Parameter, Parameters } from "../../decorators";
+import { GitHubSourceRepoParameters } from "../common/params/GitHubSourceRepoParameters";
 import { SourceRepoParameters } from "../common/params/SourceRepoParameters";
+import { GitHubRepoCreationParameters } from "./GitHubRepoCreationParameters";
 import { NewRepoCreationParameters } from "./NewRepoCreationParameters";
 
 /**
- * The parameters needed to create a new repo from a seed
+ * The parameters needed to create a new repo from a seed.
+ * Defaults to use GitHub.com, but subclasses can override the source and target parameters.
  */
 @Parameters()
 export class BaseSeedDrivenGeneratorParameters {
-
-    public source = new SourceRepoParameters();
-
-    public target = new NewRepoCreationParameters();
 
     @Parameter({
         pattern: /^(?:true|false)$/,
@@ -25,5 +24,13 @@ export class BaseSeedDrivenGeneratorParameters {
 
     @MappedParameter(MappedParameters.GitHubWebHookUrl)
     public webhookUrl: string;
+
+    /**
+     * Subclasses can override this for non GitHub target strategies.
+     * @param {SourceRepoParameters} source
+     * @param {NewRepoCreationParameters} target
+     */
+    constructor(public source: SourceRepoParameters = new GitHubSourceRepoParameters(),
+                public target: NewRepoCreationParameters = new GitHubRepoCreationParameters()) {}
 
 }

--- a/src/operations/generate/BaseSeedDrivenGeneratorParameters.ts
+++ b/src/operations/generate/BaseSeedDrivenGeneratorParameters.ts
@@ -1,4 +1,4 @@
-import { MappedParameter, MappedParameters, Parameter, Parameters } from "../../decorators";
+import { Parameter, Parameters } from "../../decorators";
 import { GitHubSourceRepoParameters } from "../common/params/GitHubSourceRepoParameters";
 import { SourceRepoParameters } from "../common/params/SourceRepoParameters";
 import { GitHubRepoCreationParameters } from "./GitHubRepoCreationParameters";
@@ -21,9 +21,6 @@ export class BaseSeedDrivenGeneratorParameters {
         displayable: true,
     })
     public addAtomistWebhook: boolean = false;
-
-    @MappedParameter(MappedParameters.GitHubWebHookUrl)
-    public webhookUrl: string;
 
     /**
      * Subclasses can override this for non GitHub target strategies.

--- a/src/operations/generate/GitHubRepoCreationParameters.ts
+++ b/src/operations/generate/GitHubRepoCreationParameters.ts
@@ -1,4 +1,4 @@
-import { Secret, Secrets } from "../../decorators";
+import { MappedParameter, MappedParameters, Secret, Secrets } from "../../decorators";
 import { GitHubRepoRef } from "../common/GitHubRepoRef";
 import { ProjectOperationCredentials } from "../common/ProjectOperationCredentials";
 import { RemoteRepoRef } from "../common/RepoId";
@@ -11,6 +11,9 @@ export class GitHubRepoCreationParameters extends NewRepoCreationParameters {
 
     @Secret(Secrets.userToken(["repo", "user:email", "read:user"]))
     public githubToken;
+
+    @MappedParameter(MappedParameters.GitHubWebHookUrl)
+    public webhookUrl: string;
 
     get credentials(): ProjectOperationCredentials {
         return { token: this.githubToken };

--- a/src/operations/generate/GitHubRepoCreationParameters.ts
+++ b/src/operations/generate/GitHubRepoCreationParameters.ts
@@ -1,0 +1,31 @@
+import { Secret, Secrets } from "../../decorators";
+import { GitHubRepoRef } from "../common/GitHubRepoRef";
+import { ProjectOperationCredentials } from "../common/ProjectOperationCredentials";
+import { RemoteRepoRef } from "../common/RepoId";
+import { NewRepoCreationParameters } from "./NewRepoCreationParameters";
+
+/**
+ * Parameters common to all generators that create new repositories
+ */
+export class GitHubRepoCreationParameters extends NewRepoCreationParameters {
+
+    @Secret(Secrets.userToken(["repo", "user:email", "read:user"]))
+    public githubToken;
+
+    get credentials(): ProjectOperationCredentials {
+        return { token: this.githubToken };
+    }
+
+    /**
+     * Return a single RepoRef or undefined if we're not identifying a single repo
+     * This implementation returns a GitHub.com repo but it can be overriden
+     * to return any kind of repo
+     * @return {RepoRef}
+     */
+    get repoRef(): RemoteRepoRef {
+        return (!!this.owner && !!this.repo) ?
+            new GitHubRepoRef(this.owner, this.repo) :
+            undefined;
+    }
+
+}

--- a/src/operations/generate/NewRepoCreationParameters.ts
+++ b/src/operations/generate/NewRepoCreationParameters.ts
@@ -46,6 +46,8 @@ export abstract class NewRepoCreationParameters implements Credentialed, RepoId,
     })
     public visibility: "public" | "private" = "public";
 
+    public webhookUrl: string;
+
     public abstract credentials: ProjectOperationCredentials;
 
     /**

--- a/src/operations/generate/NewRepoCreationParameters.ts
+++ b/src/operations/generate/NewRepoCreationParameters.ts
@@ -1,5 +1,4 @@
-import { MappedParameter, MappedParameters, Parameter, Secret, Secrets } from "../../decorators";
-import { GitHubRepoRef } from "../common/GitHubRepoRef";
+import { MappedParameter, MappedParameters, Parameter } from "../../decorators";
 import { Credentialed } from "../common/params/Credentialed";
 import { GitHubNameRegExp } from "../common/params/gitHubPatterns";
 import { RemoteLocator } from "../common/params/RemoteLocator";
@@ -9,10 +8,7 @@ import { RemoteRepoRef, RepoId } from "../common/RepoId";
 /**
  * Parameters common to all generators that create new repositories
  */
-export class NewRepoCreationParameters implements Credentialed, RepoId, RemoteLocator {
-
-    @Secret(Secrets.userToken(["repo", "user:email", "read:user"]))
-    public githubToken;
+export abstract class NewRepoCreationParameters implements Credentialed, RepoId, RemoteLocator {
 
     @MappedParameter(MappedParameters.GitHubOwner)
     public owner: string;
@@ -50,9 +46,7 @@ export class NewRepoCreationParameters implements Credentialed, RepoId, RemoteLo
     })
     public visibility: "public" | "private" = "public";
 
-    get credentials(): ProjectOperationCredentials {
-        return { token: this.githubToken };
-    }
+    public abstract credentials: ProjectOperationCredentials;
 
     /**
      * Return a single RepoRef or undefined if we're not identifying a single repo
@@ -60,10 +54,6 @@ export class NewRepoCreationParameters implements Credentialed, RepoId, RemoteLo
      * to return any kind of repo
      * @return {RepoRef}
      */
-    get repoRef(): RemoteRepoRef {
-        return (!!this.owner && !!this.repo) ?
-            new GitHubRepoRef(this.owner, this.repo) :
-            undefined;
-    }
+    public abstract repoRef: RemoteRepoRef;
 
 }

--- a/src/operations/generate/support/addAtomistWebhook.ts
+++ b/src/operations/generate/support/addAtomistWebhook.ts
@@ -37,7 +37,7 @@ function addWebhook(p: GitProject, params: BaseSeedDrivenGeneratorParameters): P
     if (!isGitHubRepoRef(p.id)) {
         return logAndFail("Unable to add Atomist web hook: Not a GitHub repo [%j]", p.id);
     }
-    if (!params.webhookUrl) {
+    if (!params.target.webhookUrl) {
         return logAndFail("Requested to add webhook but no URL provided");
     }
     if (!isTokenCredentials(params.target.credentials)) {
@@ -49,7 +49,7 @@ function addWebhook(p: GitProject, params: BaseSeedDrivenGeneratorParameters): P
         events: ["*"],
         active: true,
         config: {
-            url: params.webhookUrl,
+            url: params.target.webhookUrl,
             content_type: "json",
         },
     };

--- a/test/api/generatorEndToEndTest.ts
+++ b/test/api/generatorEndToEndTest.ts
@@ -15,6 +15,7 @@ import { RemoteRepoRef } from "../../src/operations/common/RepoId";
 import { BaseSeedDrivenGeneratorParameters } from "../../src/operations/generate/BaseSeedDrivenGeneratorParameters";
 import { generate } from "../../src/operations/generate/generatorUtils";
 import { GenericGenerator } from "../../src/operations/generate/GenericGenerator";
+import { GitHubRepoCreationParameters } from "../../src/operations/generate/GitHubRepoCreationParameters";
 import { RemoteGitProjectPersister } from "../../src/operations/generate/remoteGitProjectPersister";
 import { GitCommandGitProject } from "../../src/project/git/GitCommandGitProject";
 import { LocalProject } from "../../src/project/local/LocalProject";
@@ -64,7 +65,7 @@ describe("generator end to end", () => {
         params.source.repo = "spring-rest-seed";
         params.target.owner = TargetOwner;
         params.target.repo = repoName;
-        params.target.githubToken = GitHubToken;
+        (params.target as GitHubRepoCreationParameters).githubToken = GitHubToken;
         generator.handle(MockHandlerContext as HandlerContext, params)
             .then(result => {
                 assert(result.code === 0);

--- a/test/operations/generate/generatorToCommandTest.ts
+++ b/test/operations/generate/generatorToCommandTest.ts
@@ -7,6 +7,7 @@ import { HandlerContext } from "../../../src/HandlerContext";
 import { RedirectResult } from "../../../src/HandlerResult";
 import { BaseSeedDrivenGeneratorParameters } from "../../../src/operations/generate/BaseSeedDrivenGeneratorParameters";
 import { generatorHandler } from "../../../src/operations/generate/generatorToCommand";
+import { GitHubRepoCreationParameters } from "../../../src/operations/generate/GitHubRepoCreationParameters";
 import { mockProjectPersister } from "./generatorUtilsTest";
 
 describe("generatorToCommand", () => {
@@ -41,7 +42,7 @@ describe("generatorToCommand", () => {
         params.source.repo = "spring-rest-seed";
         params.target.owner = owner;
         params.target.repo = repo;
-        params.target.githubToken = "artificialnocturne";
+        (params.target as GitHubRepoCreationParameters).githubToken = "artificialnocturne";
         params.webhookUrl = url;
         params.addAtomistWebhook = true;
 
@@ -97,7 +98,7 @@ describe("generatorToCommand", () => {
         params.source.repo = "spring-rest-seed";
         params.target.owner = owner;
         params.target.repo = repo;
-        params.target.githubToken = "artificialnocturne";
+        (params.target as GitHubRepoCreationParameters).githubToken = "artificialnocturne";
         params.webhookUrl = url;
         params.addAtomistWebhook = false;
 

--- a/test/operations/generate/generatorToCommandTest.ts
+++ b/test/operations/generate/generatorToCommandTest.ts
@@ -43,7 +43,7 @@ describe("generatorToCommand", () => {
         params.target.owner = owner;
         params.target.repo = repo;
         (params.target as GitHubRepoCreationParameters).githubToken = "artificialnocturne";
-        params.webhookUrl = url;
+        params.target.webhookUrl = url;
         params.addAtomistWebhook = true;
 
         const gen = generatorHandler(
@@ -99,7 +99,7 @@ describe("generatorToCommand", () => {
         params.target.owner = owner;
         params.target.repo = repo;
         (params.target as GitHubRepoCreationParameters).githubToken = "artificialnocturne";
-        params.webhookUrl = url;
+        params.target.webhookUrl = url;
         params.addAtomistWebhook = false;
 
         const gen = generatorHandler(


### PR DESCRIPTION
Backward compatible. Makes it possible to generate using BitBucket or GHE by pushing GitHub mapped parameters down into subclasses.

Have tested this build with `spring-automations` to verify it still works via Slack.