### PR TITLE
Subscription parameters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -174,9 +174,9 @@
       }
     },
     "@types/highlight.js": {
-      "version": "9.12.2",
-      "resolved": "https://registry.npmjs.org/@types/highlight.js/-/highlight.js-9.12.2.tgz",
-      "integrity": "sha512-y5x0XD/WXDaGSyiTaTcKS4FurULJtSiYbGTeQd0m2LYZGBcZZ/7fM6t5H/DzeUF+kv8y6UfmF6yJABQsHcp9VQ==",
+      "version": "9.1.8",
+      "resolved": "https://registry.npmjs.org/@types/highlight.js/-/highlight.js-9.1.8.tgz",
+      "integrity": "sha1-0ifxi8uPPxh+FpZfJESFmgRol1g=",
       "dev": true
     },
     "@types/inquirer": {
@@ -4303,50 +4303,92 @@
       "integrity": "sha1-7+fUEj2KxSr/9/QMfk3sUmYAj7Q="
     },
     "typedoc": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.10.0.tgz",
-      "integrity": "sha512-+lnM/ZAv+JHfeEpGcdoE++1nsHFmfexg64gCUsQEyxzfmGJrJ2gXcaKv0dZVrxckdr9m9S6ty+OAT0Z8NICkLg==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.9.0.tgz",
+      "integrity": "sha512-numP0CtcUK4I1Vssw6E1N/FjyJWpWqhLT4Zb7Gw3i7ca3ElnYh6z41Y/tcUhMsMYn6L8b67E/Fu4XYYKkNaLbA==",
       "dev": true,
       "requires": {
-        "@types/fs-extra": "5.0.0",
-        "@types/handlebars": "4.0.36",
-        "@types/highlight.js": "9.12.2",
-        "@types/lodash": "4.14.99",
+        "@types/fs-extra": "4.0.0",
+        "@types/handlebars": "4.0.31",
+        "@types/highlight.js": "9.1.8",
+        "@types/lodash": "4.14.74",
         "@types/marked": "0.3.0",
-        "@types/minimatch": "3.0.3",
-        "@types/shelljs": "0.7.7",
-        "fs-extra": "5.0.0",
+        "@types/minimatch": "2.0.29",
+        "@types/shelljs": "0.7.0",
+        "fs-extra": "4.0.3",
         "handlebars": "4.0.11",
         "highlight.js": "9.12.0",
         "lodash": "4.17.4",
         "marked": "0.3.12",
         "minimatch": "3.0.4",
         "progress": "2.0.0",
-        "shelljs": "0.8.1",
+        "shelljs": "0.7.8",
         "typedoc-default-themes": "0.5.0",
-        "typescript": "2.7.1"
+        "typescript": "2.4.1"
       },
       "dependencies": {
-        "@types/lodash": {
-          "version": "4.14.99",
-          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.99.tgz",
-          "integrity": "sha512-h9uv6EUxjfDWNmJCNEoulQF/pFS4ua09LgSGjj6GgmIoyJ/MO5JsK8m9y+9CoG+8j2kDWCW+piPdR9fL7QoQYA==",
-          "dev": true
-        },
-        "@types/shelljs": {
-          "version": "0.7.7",
-          "resolved": "https://registry.npmjs.org/@types/shelljs/-/shelljs-0.7.7.tgz",
-          "integrity": "sha512-37gn9J75TVAhhmzBqoX0vzQodsjzri1SxElMX+Wk092IobNZSGW/8X4ygLOQOrKjCQr5nxGN9Ik0UA3fSdL1Pw==",
+        "@types/fs-extra": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-4.0.0.tgz",
+          "integrity": "sha512-PlKJw6ujJXLJjbvB3T0UCbY3jibKM6/Ya5cc9j1q+mYDeK3aR4Dp+20ZwxSuvJr9mIoPxp7+IL4aMOEvsscRTA==",
           "dev": true,
           "requires": {
-            "@types/glob": "5.0.35",
             "@types/node": "9.4.0"
           }
         },
+        "@types/handlebars": {
+          "version": "4.0.31",
+          "resolved": "https://registry.npmjs.org/@types/handlebars/-/handlebars-4.0.31.tgz",
+          "integrity": "sha1-p/umb6/kJxOu6I7sqNuRGS7+bnI=",
+          "dev": true
+        },
+        "@types/lodash": {
+          "version": "4.14.74",
+          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.74.tgz",
+          "integrity": "sha512-BZknw3E/z3JmCLqQVANcR17okqVTPZdlxvcIz0fJiJVLUCbSH1hK3zs9r634PVSmrzAxN+n/fxlVRiYoArdOIQ==",
+          "dev": true
+        },
+        "@types/minimatch": {
+          "version": "2.0.29",
+          "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-2.0.29.tgz",
+          "integrity": "sha1-UALhT3Xi1x5WQoHfBDHIwbSio2o=",
+          "dev": true
+        },
+        "@types/shelljs": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/@types/shelljs/-/shelljs-0.7.0.tgz",
+          "integrity": "sha1-IpwVfGvB5n1rmQ5sXhjb0v9Yz/A=",
+          "dev": true,
+          "requires": {
+            "@types/node": "9.4.0"
+          }
+        },
+        "fs-extra": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
+          "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "jsonfile": "4.0.0",
+            "universalify": "0.1.1"
+          }
+        },
+        "shelljs": {
+          "version": "0.7.8",
+          "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
+          "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
+          "dev": true,
+          "requires": {
+            "glob": "7.1.2",
+            "interpret": "1.1.0",
+            "rechoir": "0.6.2"
+          }
+        },
         "typescript": {
-          "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.1.tgz",
-          "integrity": "sha512-bqB1yS6o9TNA9ZC/MJxM0FZzPnZdtHj0xWK/IZ5khzVqdpGul/R/EIiHRgFXlwTD7PSIaYVnGKq1QgMCu2mnqw==",
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.4.1.tgz",
+          "integrity": "sha1-w8yxbdqgsjFN4DHn5v7onlujRrw=",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "supervisor": "^0.12.0",
     "ts-node": "^4.1.0",
     "tslint": "^5.4.3",
-    "typedoc": "^0.10.0",
+    "typedoc": "^0.9.0",
     "typescript": "2.5.3",
     "typescript-formatter": "^7.0.0"
   },

--- a/src/graph/ApolloGraphClient.ts
+++ b/src/graph/ApolloGraphClient.ts
@@ -60,7 +60,8 @@ export class ApolloGraphClient implements GraphClient {
                                       variables?: Q,
                                       options?: any,
                                       current?: string): Promise<T> {
-        return this.executeQuery<T, Q>(resolveAndReadFileSync(queryFile, current), variables, options);
+        return this.executeQuery<T, Q>(
+            resolveAndReadFileSync(queryFile, current, {}), variables, options);
     }
 
     public executeQuery<T, Q>(graphql: string,
@@ -77,10 +78,10 @@ export class ApolloGraphClient implements GraphClient {
         });
 
         return this.client.query<T>({
-            query,
-            variables,
-            ...options,
-        })
+                query,
+                variables,
+                ...options,
+            })
             .then(result => callback(result));
     }
 
@@ -88,7 +89,8 @@ export class ApolloGraphClient implements GraphClient {
                                          variables?: Q,
                                          options?: any,
                                          current?: string): Promise<T> {
-        return this.executeMutation<T, Q>(resolveAndReadFileSync(mutationFile, current), variables, options);
+        return this.executeMutation<T, Q>(
+            resolveAndReadFileSync(mutationFile, current, {}), variables, options);
     }
 
     public executeMutation<T, Q>(graphql: string,
@@ -106,10 +108,10 @@ export class ApolloGraphClient implements GraphClient {
         });
 
         return this.client.mutate<T>({
-            mutation,
-            variables,
-            ...options,
-        })
+                mutation,
+                variables,
+                ...options,
+            })
             .then(response => callback(response));
     }
 

--- a/test/graph/GraphQLTest.ts
+++ b/test/graph/GraphQLTest.ts
@@ -66,7 +66,7 @@ SomeSubscription {
             repo(first: 50, offset: 100, private: true) {
                 owner
                 name
-                bla(test: "T1L0VDKJP") {
+                bla(test: "T1L0VDKJP", fooBar: "fooBar", foo: "foo") {
                     name
                 }
             }
@@ -82,6 +82,8 @@ SomeSubscription {
                 teamId: "T1L0VDKJP",
                 offset: 100,
                 isPrivate: true,
+                foo: "foo",
+                fooBar: "fooBar",
             });
         assert.equal(query, ReplacedQuery);
     });

--- a/test/graph/GraphQLTest.ts
+++ b/test/graph/GraphQLTest.ts
@@ -58,4 +58,18 @@ query Repos($teamId: ID!, $offset: Int!) {
         const errors = GraphQL.validateQuery(query);
         assert(errors.length === 0);
     });
+
+    it("should successfully load query from relative path and replace parameters in subscription", () => {
+        const query = GraphQL.subscriptionFromFile(
+            "./someSubscription",
+            __dirname,
+            {
+                teamId: "T1L0VDKJP",
+                offset: 100,
+                isPrivate: true,
+            });
+        assert(query.includes(`"T1L0VDKJP"`));
+        assert(query.includes("100"));
+        assert(query.includes("private: true"));
+    });
 });

--- a/test/graph/GraphQLTest.ts
+++ b/test/graph/GraphQLTest.ts
@@ -59,6 +59,21 @@ query Repos($teamId: ID!, $offset: Int!) {
         assert(errors.length === 0);
     });
 
+    const ReplacedQuery = `subscription
+SomeSubscription {
+    ChatTeam(id: "T1L0VDKJP") {
+        orgs {
+            repo(first: 50, offset: 100, private: true) {
+                owner
+                name
+                bla(test: "T1L0VDKJP") {
+                    name
+                }
+            }
+        }
+    }
+}`;
+
     it("should successfully load query from relative path and replace parameters in subscription", () => {
         const query = GraphQL.subscriptionFromFile(
             "./someSubscription",
@@ -68,8 +83,6 @@ query Repos($teamId: ID!, $offset: Int!) {
                 offset: 100,
                 isPrivate: true,
             });
-        assert(query.includes(`"T1L0VDKJP"`));
-        assert(query.includes("100"));
-        assert(query.includes("private: true"));
+        assert.equal(query, ReplacedQuery);
     });
 });

--- a/test/graph/someSubscription.graphql
+++ b/test/graph/someSubscription.graphql
@@ -1,9 +1,17 @@
-query SomeSubscription {
+subscription
+SomeSubscription(
+$teamId: ID!,
+$isPrivate: Boolean!,
+$offset: Int!
+) {
     ChatTeam(id: $teamId) {
         orgs {
-            repo(first: 100, offset: $offset, private: $isPrivate) {
+            repo(first: 50, offset: $offset, private: $isPrivate) {
                 owner
                 name
+                bla(test: $teamId) {
+                    name
+                }
             }
         }
     }

--- a/test/graph/someSubscription.graphql
+++ b/test/graph/someSubscription.graphql
@@ -1,7 +1,7 @@
-query SomeOtherQuery($teamId: ID!, $offset: Int!) {
+query SomeSubscription {
     ChatTeam(id: $teamId) {
         orgs {
-            repo(first: 100, offset: $offset) {
+            repo(first: 100, offset: $offset, private: $isPrivate) {
                 owner
                 name
             }

--- a/test/graph/someSubscription.graphql
+++ b/test/graph/someSubscription.graphql
@@ -3,13 +3,15 @@ SomeSubscription(
 $teamId: ID!,
 $isPrivate: Boolean!,
 $offset: Int!
+$foo: String!,
+$fooBar: String!,
 ) {
     ChatTeam(id: $teamId) {
         orgs {
             repo(first: 50, offset: $offset, private: $isPrivate) {
                 owner
                 name
-                bla(test: $teamId) {
+                bla(test: $teamId, fooBar: $fooBar, foo: $foo) {
                     name
                 }
             }


### PR DESCRIPTION
This allows to specify the usage of parameters when using `GraqhQL.subscriptionFromFile(path, current, parameters))`

eg. the following graphql file has three parameters:

```
subscription SomeSubscription {
    ChatTeam(id: $teamId) {
        orgs {
            repo(first: 100, offset: $offset, private: $isPrivate) {
                owner
                name
            }
        }
    }
}
```

When using this with

```
const query = GraphQL.subscriptionFromFile(
            "./someSubscription",
            __dirname,
            {
                teamId: "T1L0VDKJP",
                offset: 100,
                isPrivate: true,
            });
```

the variables get replaced in the predicates.

NOTE: this doesn't give you full support for variables in subscriptions right now but we don't offer that in the API anyway as of today. This is a good first step.