### PR TITLE
handle newline in json

### DIFF
--- a/src/project/util/jsonUtils.ts
+++ b/src/project/util/jsonUtils.ts
@@ -30,7 +30,7 @@ export function doWithJson<M, P extends ProjectAsync = ProjectAsync>(
     });
 }
 
-const spacePossibilities = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, " ", "  ", "\t"];
+const spacePossibilities = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, " ", "  ", "\t"];
 
 /**
  * Update the object form of the given JSON content and write
@@ -47,7 +47,7 @@ export function manipulate(jsonIn: string, manipulation: JsonManipulation, conte
     try {
         const obj = JSON.parse(jsonIn);
 
-        let space: number | string = 0;
+        let space: number | string = 2;
         for (const sp of spacePossibilities) {
             const maybe = JSON.stringify(obj, null, sp);
             if (jsonIn === maybe) {

--- a/src/project/util/jsonUtils.ts
+++ b/src/project/util/jsonUtils.ts
@@ -45,12 +45,15 @@ export function manipulate(jsonIn: string, manipulation: JsonManipulation, conte
     }
 
     try {
+        const newline = jsonIn.endsWith("\n"); // does this work on Windows?
+        const jsonToCompare = newline ? jsonIn.replace(/\n$/, "") : jsonIn;
+
         const obj = JSON.parse(jsonIn);
 
         let space: number | string = 2;
         for (const sp of spacePossibilities) {
             const maybe = JSON.stringify(obj, null, sp);
-            if (jsonIn === maybe) {
+            if (jsonToCompare === maybe) {
                 logger.debug(`Definitely inferred space as [${sp}]`);
                 space = sp;
                 break;
@@ -60,7 +63,7 @@ export function manipulate(jsonIn: string, manipulation: JsonManipulation, conte
         logger.debug(`Inferred space is [${space}]`);
 
         manipulation(obj);
-        return JSON.stringify(obj, null, space);
+        return JSON.stringify(obj, null, space) + (newline ? "\n" : "");
     } catch (e) {
         logger.warn("Syntax error parsing supposed JSON (%s). Context:[%s]. Alleged JSON:\n%s", e, context, jsonIn);
         return jsonIn;

--- a/test/project/util/jsonUtilsTest.ts
+++ b/test/project/util/jsonUtilsTest.ts
@@ -48,6 +48,21 @@ describe("jsonUtils", () => {
             JSON.parse(transformed);
         });
 
+        it("should retain spacing of 2", () => {
+            const json = fromPackageJson("@atomist/test");
+            const transformed = manipulate(json,
+                o => o);
+            // Should not change it
+            assert.equal(transformed, json);
+        });
+
+        it("should retain spacing of 0", () => {
+            const json = simpleJson(25);
+            const transformed = manipulate(json, o => o);
+            assert(transformed === json,
+                "\n" + json + "\n" + transformed);
+        });
+
     });
 
     describe("doWithJson", () => {

--- a/test/project/util/jsonUtilsTest.ts
+++ b/test/project/util/jsonUtilsTest.ts
@@ -63,6 +63,13 @@ describe("jsonUtils", () => {
                 "\n" + json + "\n" + transformed);
         });
 
+        it("should retain spacing of 0 with a newline", () => {
+            const json = simpleJson(25) + "\n";
+            const transformed = manipulate(json, o => o);
+            assert(transformed === json,
+                "\n" + json + "\n" + transformed);
+        });
+
     });
 
     describe("doWithJson", () => {


### PR DESCRIPTION
the generator rewrote my json with 0 spacing, because it had a newline at the end of the file so it didn't recognize the spacing of 2.

This defaults to 2 instead of 0, and also removes and replaces newlines when looking for spacing, so as not to change that.