### PR TITLE
Added beforePersist and afterPersist hooks to EditMode

### DIFF
--- a/src/operations/edit/editModes.ts
+++ b/src/operations/edit/editModes.ts
@@ -19,6 +19,22 @@ export function toEditModeFactory(em: EditMode | EditModeFactory): EditModeFacto
 export interface EditMode {
 
     message: string;
+
+    /**
+     * Optional method to perform any additional actions on the project before
+     * applying the edit to persistent store--for example, getting the sha from a git repo
+     * @param {Project} p
+     * @return {Promise<any>}
+     */
+    beforePersist?(p: Project): Promise<any>;
+
+    /**
+     * Optional method to perform any additional actions on the project after
+     * applying the edit to persistent store--for example, setting a GitHub status
+     * @param {Project} p
+     * @return {Promise<any>}
+     */
+    afterPersist?(p: Project): Promise<any>;
 }
 
 export function isEditMode(em: any): em is EditMode {

--- a/src/operations/edit/editModes.ts
+++ b/src/operations/edit/editModes.ts
@@ -21,14 +21,6 @@ export interface EditMode {
     message: string;
 
     /**
-     * Optional method to perform any additional actions on the project before
-     * applying the edit to persistent store--for example, getting the sha from a git repo
-     * @param {Project} p
-     * @return {Promise<any>}
-     */
-    beforePersist?(p: Project): Promise<any>;
-
-    /**
      * Optional method to perform any additional actions on the project after
      * applying the edit to persistent store--for example, setting a GitHub status
      * @param {Project} p

--- a/src/operations/support/editorUtils.ts
+++ b/src/operations/support/editorUtils.ts
@@ -21,26 +21,33 @@ import { EditResult, ProjectEditor, successfulEdit } from "../edit/projectEditor
  * set to true by the editor and the git status is not dirty, this is a developer error
  * which should result in a runtime error.
  * @param context handler context for this operation
- * @param repo repo id
+ * @param p project
  * @param editor editor to use
- * @param ei how to persist the edit
+ * @param editMode how to persist the edit
  * @param parameters to editor
  * @return EditResult instance that reports as to whether the project was actually edited
  */
-export function editRepo<P extends EditorOrReviewerParameters>(context: HandlerContext,
-                                                               repo: Project,
-                                                               editor: ProjectEditor<P>,
-                                                               ei: EditMode,
-                                                               parameters?: P): Promise<EditResult> {
-    if (isPullRequest(ei)) {
-        return editProjectUsingPullRequest(context, repo as GitProject, editor, ei, parameters);
-    } else if (isBranchCommit(ei)) {
-        return editProjectUsingBranch(context, repo as GitProject, editor, ei, parameters);
-    } else if (isCustomExecutionEditMode(ei)) {
-        return ei.edit(repo, editor, context, parameters);
+export async function editRepo<P extends EditorOrReviewerParameters>(context: HandlerContext,
+                                                                     p: Project,
+                                                                     editor: ProjectEditor<P>,
+                                                                     editMode: EditMode,
+                                                                     parameters?: P): Promise<EditResult> {
+    if (!!editMode.beforePersist) {
+        await editMode.beforePersist(p);
+    }
+    const after = x => !!editMode.afterPersist ? editMode.afterPersist(p).then(() => x) : x;
+    if (isPullRequest(editMode)) {
+        return editProjectUsingPullRequest(context, p as GitProject, editor, editMode, parameters)
+            .then(after);
+    } else if (isBranchCommit(editMode)) {
+        return editProjectUsingBranch(context, p as GitProject, editor, editMode, parameters)
+            .then(after);
+    } else if (isCustomExecutionEditMode(editMode)) {
+        return editMode.edit(p, editor, context, parameters)
+            .then(after);
     } else {
         // No edit to do
-        return Promise.resolve(successfulEdit(repo, true));
+        return Promise.resolve(successfulEdit(p, true));
     }
 }
 

--- a/src/operations/support/editorUtils.ts
+++ b/src/operations/support/editorUtils.ts
@@ -27,14 +27,11 @@ import { EditResult, ProjectEditor, successfulEdit } from "../edit/projectEditor
  * @param parameters to editor
  * @return EditResult instance that reports as to whether the project was actually edited
  */
-export async function editRepo<P extends EditorOrReviewerParameters>(context: HandlerContext,
-                                                                     p: Project,
-                                                                     editor: ProjectEditor<P>,
-                                                                     editMode: EditMode,
-                                                                     parameters?: P): Promise<EditResult> {
-    if (!!editMode.beforePersist) {
-        await editMode.beforePersist(p);
-    }
+export function editRepo<P extends EditorOrReviewerParameters>(context: HandlerContext,
+                                                               p: Project,
+                                                               editor: ProjectEditor<P>,
+                                                               editMode: EditMode,
+                                                               parameters?: P): Promise<EditResult> {
     const after = x => !!editMode.afterPersist ? editMode.afterPersist(p).then(() => x) : x;
     if (isPullRequest(editMode)) {
         return editProjectUsingPullRequest(context, p as GitProject, editor, editMode, parameters)


### PR DESCRIPTION
This is useful, for example, to be able to set a GitHub status on a new branch.