### PR TITLE
Add branch as an optional field to RepoRef

### DIFF
--- a/src/operations/common/AbstractRemoteRepoRef.ts
+++ b/src/operations/common/AbstractRemoteRepoRef.ts
@@ -6,6 +6,8 @@ import { RemoteRepoRef } from "./RepoId";
 
 export abstract class AbstractRepoRef implements RemoteRepoRef {
 
+    public branch?: string;
+
     constructor(public remoteBase: string,
                 public owner: string,
                 public repo: string,

--- a/src/operations/common/GitHubRepoRef.ts
+++ b/src/operations/common/GitHubRepoRef.ts
@@ -7,6 +7,7 @@ import axios from "axios";
 import { logger } from "../../internal/util/logger";
 import { Configurable } from "../../project/git/Configurable";
 import { AbstractRepoRef } from "./AbstractRemoteRepoRef";
+import { GitShaRegExp } from "./params/gitHubPatterns";
 
 export const GitHubDotComBase = "https://api.github.com";
 
@@ -14,6 +15,18 @@ export const GitHubDotComBase = "https://api.github.com";
  * GitHub repo ref
  */
 export class GitHubRepoRef extends AbstractRepoRef {
+
+    public static from(params: { owner: string, repo: string, sha?: string, rawApiBase?: string, path?: string, branch?: string }): GitHubRepoRef {
+        if (params.sha && !params.sha.match(GitShaRegExp.pattern)) {
+            throw new Error("You provided an invalid SHA: " + params.sha);
+        }
+        /*
+         * Replicate legacy behavior of: if we have only a branch and not a sha, put it in the sha.
+         */
+        const result = new GitHubRepoRef(params.owner, params.repo, params.sha || params.branch, params.rawApiBase, params.path);
+        result.branch = params.branch;
+        return result;
+    }
 
     public readonly kind = "github";
 
@@ -40,7 +53,7 @@ export class GitHubRepoRef extends AbstractRepoRef {
     public setUserConfig(credentials: ProjectOperationCredentials, project: Configurable): Promise<ActionResult<any>> {
         const config = headers(credentials);
         return Promise.all([axios.get(`${this.apiBase}/user`, config),
-        axios.get(`${this.apiBase}/user/emails`, config)])
+            axios.get(`${this.apiBase}/user/emails`, config)])
             .then(results => {
                 const name = results[0].data.name;
                 let email = results[0].data.email;

--- a/src/operations/common/RepoId.ts
+++ b/src/operations/common/RepoId.ts
@@ -24,12 +24,21 @@ export class SimpleRepoId implements RepoId {
  */
 export interface RepoRef extends RepoId {
 
+    /*
+     * Might contain a sha, might contain a ref (for backwards compatibility)
+     * Providing a sha here and a branch in `branch` instead is encouraged.
+     */
     sha?: string;
 
     /**
      * Path from root, using / syntax. If undefined or the empty string, use the root of the repo.
      */
     path?: string;
+
+    /*
+     * If this is populated, then `sha` should contain a sha (it may also contain the same branch name, for backwards compatibility)
+     */
+    branch?: string;
 
 }
 

--- a/src/operations/common/params/gitHubPatterns.ts
+++ b/src/operations/common/params/gitHubPatterns.ts
@@ -9,3 +9,8 @@ export const GitBranchRegExp = {
     validInput: "a valid Git branch name, see" +
     " https://www.kernel.org/pub/software/scm/git/docs/git-check-ref-format.html",
 };
+
+export const GitShaRegExp = {
+    pattern: /^[0-9a-f]{40}$/,
+    validInput: "40 hex digits, lowercase",
+};

--- a/src/operations/support/editorUtils.ts
+++ b/src/operations/support/editorUtils.ts
@@ -73,26 +73,32 @@ export function editProjectUsingBranch<P>(context: HandlerContext,
 /**
  * Perform git operation on the project only if edited != false or status is dirty
  * @param {EditResult<GitProject>} r
- * @param {() => Promise<EditResult>} gitop
+ * @param {() => Promise<EditResult>} gitop what to do with a dirty project
  * @return {Promise<EditResult>}
  */
 function doWithEditResult(r: EditResult<GitProject>, gitop: () => Promise<EditResult>): Promise<EditResult> {
     if (r.edited === true) {
-        // Do a second check to see if the project is dirty
+        logger.info("Declared dirty; executing git operation. Project: %j\n Directory: %s", r.target.id, r.target.baseDir);
         return gitop();
     }
     if (r.edited === undefined) {
         // Check git status
         return r.target.gitStatus()
             .then(status => {
-                return status.isClean ? ({
-                    target: r.target,
-                    success: true,
-                    edited: false,
-                }) : gitop();
+                if (status.isClean) {
+                    logger.info("Observed clean; skipping git operation. Project: %j\n Directory: %s", r.target.id, r.target.baseDir);
+                    return {
+                        target: r.target,
+                        success: true,
+                        edited: false,
+                    }
+                } else {
+                    logger.info("Observed dirty; executing git operation. Project: %j\n Directory: %s", r.target.id, r.target.baseDir);
+                    return gitop()
+                }
             });
     }
-    logger.info("NOT committing %j as it's not dirty, edited=%s", r.target.id, r.edited);
+    logger.info("Declared not dirty; skipping git operation. Project: %j\n Directory: %s\nEdited=%s", r.target.id, r.target.baseDir, r.edited);
     return Promise.resolve(r);
 }
 

--- a/src/operations/support/editorUtils.ts
+++ b/src/operations/support/editorUtils.ts
@@ -91,10 +91,10 @@ function doWithEditResult(r: EditResult<GitProject>, gitop: () => Promise<EditRe
                         target: r.target,
                         success: true,
                         edited: false,
-                    }
+                    };
                 } else {
                     logger.info("Observed dirty; executing git operation. Project: %j\n Directory: %s", r.target.id, r.target.baseDir);
-                    return gitop()
+                    return gitop();
                 }
             });
     }

--- a/test/configurationTest.ts
+++ b/test/configurationTest.ts
@@ -288,7 +288,7 @@ describe("configuration", () => {
             assert(c.applicationEvents.enabled === true);
             assert(c.applicationEvents.teamId === "T1L0VDKJP");
             assert(c.cluster.enabled === false);
-        }).timeout(4000);
+        }).timeout(5000);
 
     });
 

--- a/test/operations/common/GitHubRepoRefTest.ts
+++ b/test/operations/common/GitHubRepoRefTest.ts
@@ -1,4 +1,3 @@
-
 import "mocha";
 
 import * as assert from "power-assert";
@@ -22,6 +21,16 @@ describe("GitHubRepoRef", () => {
         const apiBase = "https//somewhere.com";
         const gh = new GitHubRepoRef("owner", "repo", undefined, apiBase + "/");
         assert(gh.apiBase === apiBase);
+    });
+
+    it("puts the branch in the sha if sha is not provided", () => {
+        // this is to replicate the behavior when branch wasn't an option
+        const gh = GitHubRepoRef.from({owner: "owner", repo: "repo", branch: "fester"});
+        assert.equal(gh.sha, "fester");
+    });
+
+    it("does not let you provide a sha that is not a sha, when you could put that in branch", () => {
+        assert.throws(() => GitHubRepoRef.from({owner: "owner", repo: "repo", sha: "fester"}));
     });
 
 });


### PR DESCRIPTION
We often want to specify both this and the SHA
especially for editors; they must have a branch. and statuses must have a sha.