### PR TITLE
editorChain now procedural for clarity

### DIFF
--- a/src/operations/edit/projectEditorOps.ts
+++ b/src/operations/edit/projectEditorOps.ts
@@ -1,18 +1,6 @@
-import { actionChainWithCombiner } from "../../action/actionOps";
-import { isActionResult } from "../../action/ActionResult";
+import { logger } from "../../internal/util/logger";
 import { Project } from "../../project/Project";
-import {
-    AnyProjectEditor, EditResult, flushAndSucceed, ProjectEditor, SimpleProjectEditor,
-    successfulEdit,
-} from "./projectEditor";
-
-function combineEditResults(r1: EditResult, r2: EditResult): EditResult {
-    return {
-        ...r1, ...r2,
-        edited: (r1.edited || r2.edited) ? true :
-            (r1.edited === false && r2.edited === false) ? false : undefined,
-    };
-}
+import { AnyProjectEditor, EditResult, ProjectEditor, successfulEdit, toEditor } from "./projectEditor";
 
 /**
  * Chain the editors, in the given order
@@ -20,30 +8,34 @@ function combineEditResults(r1: EditResult, r2: EditResult): EditResult {
  * @return {ProjectEditor}
  */
 export function chainEditors(...projectEditors: AnyProjectEditor[]): ProjectEditor {
-    const alwaysReturnEditResult =
-        projectEditors.map(toEditor);
-
-    return (p, ctx, params) => {
-        const curried = alwaysReturnEditResult.map(ed => pp => ed(pp, ctx, params));
-        const chain = actionChainWithCombiner(combineEditResults,
-            ...curried);
-        return chain(p) as Promise<EditResult>;
+    const asProjectEditors = projectEditors.map(toEditor);
+    return async (p, ctx, params) => {
+        try {
+            let cumulativeResult: EditResult = {
+                target: p,
+                success: true,
+                edited: false,
+            };
+            for (const pe of asProjectEditors) {
+                const lastResult = await pe(p, ctx, params);
+                cumulativeResult = combineEditResults(lastResult, cumulativeResult);
+            }
+            return cumulativeResult;
+        } catch (error) {
+            logger.warn("Editor failure in editorChain: %s", error);
+            return {target: p, edited: false, success: false, error};
+        }
     };
 }
 
-function toEditor(pop: AnyProjectEditor): ProjectEditor {
-    return (proj, ctx, params) => (pop as SimpleProjectEditor)(proj, ctx, params)
-        .then(r => {
-            if (!r) {
-                const editorName = pop.name || "";
-                return Promise.reject(
-                    `Invalid return from ${editorName}. Should be EditResult or Project, got: <${r}>`);
-            }
-            // See what it returns
-            return isActionResult(r) ?
-                r as any as EditResult :
-                flushAndSucceed(r);
-        });
+function combineEditResults(r1: EditResult, r2: EditResult): EditResult {
+    return {
+        ...r1,
+        ...r2,
+        edited: (r1.edited || r2.edited) ? true :
+            (r1.edited === false && r2.edited === false) ? false : undefined,
+        success: r1.success && r2.success,
+    };
 }
 
 /**


### PR DESCRIPTION
- Much more readable. Hopefully fixes `editorChain` bugs
- Removes duplicate `toEditor` function