### PR TITLE
make it work like get because get works

### DIFF
--- a/src/internal/transport/express/ExpressServer.ts
+++ b/src/internal/transport/express/ExpressServer.ts
@@ -166,7 +166,7 @@ export class ExpressServer {
 
                 const payload: CommandIncoming = {
                     atomist_type: "command_handler_request",
-                    name: h.name,
+                    command: h.name,
                     rug: {},
                     correlation_context: { team: { id } },
                     corrid: guid(),


### PR DESCRIPTION
we can work around this by sending `"command": handlerName` in the post data