### PR TITLE
Move config debug statement to run

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -723,10 +723,6 @@ export function loadConfiguration(cfgPath?: string): Promise<Configuration> {
         .then(completeCfg => {
             completeCfg.postProcessors = [];
 
-            if (cluster.isMaster) {
-                logger.info("Using automation client configuration: %s", stringify(cfg, obfuscateJson));
-            }
-
             try {
                 validateConfiguration(completeCfg);
             } catch (e) {


### PR DESCRIPTION
In its current location, the debug statement printing the client
configuration did not work because the log level was defaulted to info
and was not being changed until after the statement.  Rather than
change the statement to info level as I had previously done, I move
the statement to the client run() method where it will be printed if
the logging level dictates it.