### PR TITLE
Remove previously deprecate CLIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 [Unreleased]: https://github.com/atomist/automation-client-ts/compare/0.11.2...HEAD
 
+### Removed
+
+-   Remove previously deprecated command-line utilities now superseded
+    by the combined `atomist` CLI
+
 ## [0.11.2][] - 2018-03-28
 
 [0.11.2]: https://github.com/atomist/automation-client-ts/compare/0.11.1...0.11.2

--- a/src/atomist-cli.ts
+++ b/src/atomist-cli.ts
@@ -1,5 +1,0 @@
-#!/usr/bin/env node
-import * as child_process from "child_process";
-import * as process from "process";
-console.warn("atomist-cli is deprecated, use 'atomist' instead");
-child_process.execFileSync("atomist", process.argv, { env: process.env, stdio: "inherit" });

--- a/src/atomist-client.ts
+++ b/src/atomist-client.ts
@@ -1,6 +1,0 @@
-#!/usr/bin/env node
-import * as child_process from "child_process";
-import * as process from "process";
-console.warn("atomist-client is deprecated, use 'atomist start' instead");
-process.argv.unshift("start");
-child_process.execFileSync("atomist", process.argv, { env: process.env, stdio: "inherit" });

--- a/src/atomist-config.ts
+++ b/src/atomist-config.ts
@@ -1,6 +1,0 @@
-#!/usr/bin/env node
-import * as child_process from "child_process";
-import * as process from "process";
-console.warn("atomist-config is deprecated, use 'atomist config' instead");
-process.argv.unshift("config");
-child_process.execFileSync("atomist", process.argv, { env: process.env, stdio: "inherit" });

--- a/src/git-info.ts
+++ b/src/git-info.ts
@@ -1,6 +1,0 @@
-#!/usr/bin/env node
-import * as child_process from "child_process";
-import * as process from "process";
-console.warn("git-info is deprecated, use 'atomist git' instead");
-process.argv.unshift("git");
-child_process.execFileSync("atomist", process.argv, { env: process.env, stdio: "inherit" });


### PR DESCRIPTION
Remove the deprecated command-line utilities superseded by the
combined `atomist` CLI.