### PR TITLE
Better command invocation on win32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 [Unreleased]: https://github.com/atomist/automation-client-ts/compare/0.13.0...HEAD
 
+### Fixed
+
+-   Fix running node on MS Windows [#271][271]
+
+[271]: https://github.com/atomist/automation-client-ts/issues/271
+
 ## [0.13.0][] - 2018-04-10
 
 [0.13.0]: https://github.com/atomist/automation-client-ts/compare/0.12.1...0.13.0


### PR DESCRIPTION
The Node.js executable is named `node.exe` on MS Windows.  On win32
bin scripts are installed as wrappers, not symlinks.  Use the .cmd
wrapper directly rather than trying to figure out the correct
multi-platform node incantation.  Improve abstractions and diagnostics
around command failure.

Clean up path/cwd confusion.

Towards #271 

Tested on a Windows 10 dev VM.