### PR TITLE
Reduce grace period, add namespace to app event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 [Unreleased]: https://github.com/atomist/automation-client-ts/compare/0.14.1...HEAD
 
+### Changed
+
+-   Reduce default websocket grace period to 10 seconds
+
+### Added
+
+-   Namespace to application event
+
 ## [0.14.1][] - 2018-04-30
 
 [0.14.1]: https://github.com/atomist/automation-client-ts/compare/0.14.0...0.14.1

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -320,6 +320,8 @@ function loadDefaultConfiguration(): Configuration {
         envSpecificCfg = ProductionDefaultConfiguration;
     } else if (nodeEnv === "staging" || nodeEnv === "testing") {
         envSpecificCfg = TestingDefaultConfiguration;
+    } else if (nodeEnv) {
+        cfg.environment = nodeEnv;
     }
 
     return mergeConfigs(cfg, envSpecificCfg);
@@ -767,7 +769,7 @@ export const LocalDefaultConfiguration: Configuration = {
         enabled: true,
         termination: {
             graceful: false,
-            gracePeriod: 60000,
+            gracePeriod: 10000,
         },
         compress: false,
         timeout: 10000,

--- a/src/internal/env/applicationEvent.ts
+++ b/src/internal/env/applicationEvent.ts
@@ -55,6 +55,7 @@ export function registerApplicationEvents(teamId: string): Promise<any> {
         pod: env ? env.instance_id : os.hostname(),
         host: env ? env.instance_id : os.hostname(),
         id: env ? env.instance_id : guid(),
+        namespace: env ? env.space_name : process.env.ATOMIST_ENV || process.env.NODE_ENV || "unknown",
     };
 
     if (env) {
@@ -84,6 +85,7 @@ interface ApplicationEvent {
     pod: string;
     host: string;
     id: string;
+    namespace: string;
     data?: any;
     state?: string;
     ts?: number;

--- a/test/configurationTest.ts
+++ b/test/configurationTest.ts
@@ -67,7 +67,7 @@ describe("configuration", () => {
             enabled: true,
             termination: {
                 graceful: false,
-                gracePeriod: 60000,
+                gracePeriod: 10000,
             },
             compress: false,
             timeout: 10000,


### PR DESCRIPTION
Reduce default websocket grace period to 10 seconds.

Add namespace to the application event sent to Atomist.