### PR TITLE
Support for injection of configuration values

### DIFF
--- a/src/automationClient.ts
+++ b/src/automationClient.ts
@@ -12,6 +12,7 @@ import {
     IngesterBuilder,
 } from "./ingesters";
 import { registerApplicationEvents } from "./internal/env/applicationEvent";
+import { NodeConfigSecretResolver } from "./internal/env/NodeConfigSecretResolver";
 import { ClusterMasterRequestProcessor } from "./internal/transport/cluster/ClusterMasterRequestProcessor";
 import { startWorker } from "./internal/transport/cluster/ClusterWorkerRequestProcessor";
 import { EventStoringAutomationEventListener } from "./internal/transport/EventStoringAutomationEventListener";
@@ -52,20 +53,7 @@ export class AutomationClient {
     ];
 
     constructor(public configuration: Configuration) {
-        this.automations = new BuildableAutomationServer(
-            {
-                name: configuration.name,
-                version: configuration.version,
-                policy: configuration.policy,
-                teamIds: configuration.teamIds,
-                groups: configuration.groups,
-                keywords: [],
-                token: configuration.token,
-                endpoints: {
-                    graphql: configuration.endpoints.graphql,
-                    api: configuration.endpoints.api,
-                },
-            } as AutomationServerOptions);
+        this.automations = new BuildableAutomationServer(configuration);
     }
 
     get automationServer(): AutomationServer {

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -58,9 +58,18 @@ export interface Banner {
 }
 
 /**
+ * Custom configuration you can abuse to your benefit
+ */
+export interface AnyOptions {
+
+    /** Abuse goes here */
+    [key: string]: any;
+}
+
+/**
  * Options for an automation node.
  */
-export interface AutomationOptions {
+export interface AutomationOptions extends AnyOptions {
     /**
      * Automation name.  If not given, the name is extracted from
      * the package.json.
@@ -141,8 +150,6 @@ export interface AutomationOptions {
         graphql?: string;
         api?: string;
     };
-    /** Custom configuration you can abuse to your benefit */
-    custom?: any;
     /**
      * Post-processors can be used to modify the configuration after
      * all standard configuration loading has been done and before the
@@ -151,9 +158,6 @@ export interface AutomationOptions {
      */
     postProcessors?: Array<(configuration: Configuration) => Promise<Configuration>>;
 }
-
-/** DEPRECATED use AutomationOptions */
-export type RunOptions = AutomationOptions;
 
 /**
  * Options useful when running an automation client in server mode.
@@ -318,12 +322,13 @@ export function defaultConfiguration(): Configuration {
 export function configurationValue<T>(path: string, defaultValue?: T): T  {
     const conf = automationClientInstance().configuration;
     const value = _.get(conf, path) as T;
-    if (!value && !defaultValue) {
-        throw new Error(`Required @Value '${path}' not available`);
-    } else if (!value && defaultValue) {
+
+    if (value) {
+        return value;
+    } else if (defaultValue) {
         return defaultValue;
     }
-    return value;
+    throw new Error(`Required @Value '${path}' not available`);
 }
 
 /**
@@ -828,11 +833,6 @@ export function loadConfiguration(cfgPath?: string): Promise<Configuration> {
             return Promise.resolve(completeCfg);
         });
 }
-
-/**
- * DEPRECATED: use loadConfiguration instead.
- */
-export const findConfiguration = loadConfiguration;
 
 export const LocalDefaultConfiguration: Configuration = {
     teamIds: [],

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -649,6 +649,73 @@ export function resolvePort(cfg: Configuration): number {
     return cfg.http.port;
 }
 
+const EnvironmentVariablePrefix = "ATOMIST_";
+const EnvironmentVariablesToIgnore = ["CONFIG", "CONFIG_PATH", "TEAMS", "TEAM", "TOKEN", "ENV"];
+
+/**
+ * Resolve ATOMIST_ environment variables and add them to config.
+ * Variables of like ATOMIST_custom_foo_bar will be converted to
+ * a json path of custom.foo.bar.
+ * @param {Configuration} cfg
+ */
+export function resolveEnvironmentVariables(cfg: Configuration) {
+    for (const key in process.env) {
+        if (key.startsWith(EnvironmentVariablePrefix)
+            && !EnvironmentVariablesToIgnore.some(v => `${EnvironmentVariablePrefix}${v}` === key)
+            && process.env.hasOwnProperty(key)) {
+            const path = key.slice(EnvironmentVariablePrefix.length).split("_").join(".");
+            _.update(cfg, path, () => process.env[key]);
+        }
+    }
+}
+
+/**
+ * Resolve placeholders against the process.env.
+ * Placeholders should be of form ${ENV_VAR}. Placeholders support default values
+ * in case they aren't defined: ${ENV_VAR:default value}
+ * @param {Configuration} config
+ */
+export function resolvePlaceholders(cfg: Configuration) {
+    resolvePlaceholdersRecursively(cfg);
+}
+
+function resolvePlaceholdersRecursively(obj: any) {
+    for (const property in obj) {
+        if (obj.hasOwnProperty(property)) {
+            if (typeof obj[property] === "object") {
+                resolvePlaceholdersRecursively(obj[property]);
+            } else if (typeof obj[property] === "string") {
+                obj[property] = resolvePlaceholder(obj[property]);
+            }
+        }
+    }
+}
+
+const PlaceholderExpression = /\$\{([.a-zA-Z_-]+)([.:0-9a-zA-Z-_ \" ]+)*\}/g;
+
+function resolvePlaceholder(value: string): string {
+    if (PlaceholderExpression.test(value)) {
+        PlaceholderExpression.lastIndex = 0;
+        let result;
+
+        // tslint:disable-next-line:no-conditional-assignment
+        while (result = PlaceholderExpression.exec(value)) {
+            const fm = result[0];
+            const envValue = process.env[result[1]];
+            const defaultValue = result[2] ? result[2].trim().slice(1) : undefined;
+
+            if (envValue) {
+                value = value.split(fm).join(envValue);
+            } else if (defaultValue) {
+                value = value.split(fm).join(defaultValue);
+            } else {
+                throw new Error(`Environment variable '${result[1]}' is not defined`);
+            }
+        }
+    }
+    return value;
+}
+
 /**
  * Invoke postProcessors on the provided configuration.
  */
@@ -739,6 +806,7 @@ export function loadConfiguration(cfgPath?: string): Promise<Configuration> {
         resolveTeamIds(cfg);
         resolveToken(cfg);
         resolvePort(cfg);
+        resolveEnvironmentVariables(cfg);
         resolvePlaceholders(cfg);
     } catch (e) {
         logger.error(`Failed to load configuration: ${e.message}`);
@@ -759,53 +827,6 @@ export function loadConfiguration(cfgPath?: string): Promise<Configuration> {
             }
             return Promise.resolve(completeCfg);
         });
-}
-
-/**
- * Resolves placeholders against the process.env.
- * Placeholders should be of form ${ENV_VAR}. Placeholders support default values
- * in case they aren't defined: ${ENV_VAR:default value}
- * @param {Configuration} config
- */
-export function resolvePlaceholders(cfg: Configuration) {
-    resolvePlaceholdersRecursively(cfg);
-}
-
-function resolvePlaceholdersRecursively(obj: any) {
-    for (const property in obj) {
-        if (obj.hasOwnProperty(property)) {
-            if (typeof obj[property] === "object") {
-                resolvePlaceholdersRecursively(obj[property]);
-            } else if (typeof obj[property] === "string") {
-                obj[property] = resolvePlaceholder(obj[property]);
-            }
-        }
-    }
-}
-
-const PlaceholderExpression = /\$\{([.a-zA-Z_-]+)([.:0-9a-zA-Z-_ \" ]+)*\}/g;
-
-function resolvePlaceholder(value: string): string {
-    if (PlaceholderExpression.test(value)) {
-        PlaceholderExpression.lastIndex = 0;
-        let result;
-
-        // tslint:disable-next-line:no-conditional-assignment
-        while (result = PlaceholderExpression.exec(value)) {
-            const fm = result[0];
-            const envValue = process.env[result[1]];
-            const defaultValue = result[2] ? result[2].trim().slice(1) : undefined;
-
-            if (envValue) {
-                value = value.split(fm).join(envValue);
-            } else if (defaultValue) {
-                value = value.split(fm).join(defaultValue);
-            } else {
-                throw new Error(`Environment variable '${result[1]}' is not defined`);
-            }
-        }
-    }
-    return value;
 }
 
 /**

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -1,5 +1,6 @@
 import {
     BaseParameter,
+    BaseValue,
     declareCommandHandler,
     declareEventHandler,
     declareMappedParameter,
@@ -41,9 +42,15 @@ export function Secret(uri: string) {
 /**
  * Inject a config value from the automation-client configuration
  */
-export function Value(path: string, required: boolean = true) {
+export function Value(pathOrValue: string | BaseValue) {
     return (target: any, name: string) => {
-        declareValue(target, name, path, required);
+        if (typeof pathOrValue === "string") {
+            declareValue(target, name, {
+                path: pathOrValue,
+            });
+        } else {
+            declareValue(target, name, pathOrValue);
+        }
     };
 }
 

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -7,6 +7,7 @@ import {
     declareParameters,
     declareSecret,
     declareTags,
+    declareValue,
 } from "./internal/metadata/decoratorSupport";
 import { toStringArray } from "./internal/util/string";
 
@@ -29,11 +30,20 @@ export function MappedParameter(uri: string, required: boolean = true) {
 }
 
 /**
- * Declare a secret a Rug wants to use
+ * Declare a secret an automation wants to use
  */
 export function Secret(uri: string) {
     return (target: any, name: string) => {
         declareSecret(target, name, uri);
+    };
+}
+
+/**
+ * Inject a config value from the automation-client configuration
+ */
+export function Value(path: string, required: boolean = true) {
+    return (target: any, name: string) => {
+        declareValue(target, name, path, required);
     };
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ export {
     Parameters,
     Secret,
     Secrets,
+    Value,
     Tags,
 } from "./decorators";
 
@@ -40,6 +41,7 @@ export {
 } from "./HandlerResult";
 
 import * as GraphQL from "./graph/graphQL";
+
 export { GraphQL };
 
 export { logger } from "./internal/util/logger";

--- a/src/internal/metadata/decoratorSupport.ts
+++ b/src/internal/metadata/decoratorSupport.ts
@@ -99,7 +99,7 @@ export function declareMappedParameter(target: any, name: string, uri: string, r
     if (params == null) {
         params = [];
     } else {
-        // remove any that have the same name already (i.e. if folk are calling declareParameter)
+        // remove any that have the same name already (i.e. if folk are calling declareMappedParameter)
         // use a cheeky method so that we can reuse the same array
         const found: any[] = params.filter(p => p.localKey === name);
         if (found != null && found.length > 0) {
@@ -129,12 +129,47 @@ export function declareMappedParameter(target: any, name: string, uri: string, r
     return target;
 }
 
+export function declareValue(target: any, name: string, path: string, required: boolean) {
+    let params = get_metadata(target, "__values");
+    if (params == null) {
+        params = [];
+    } else {
+        // remove any that have the same name already (i.e. if folk are calling declareConfig)
+        // use a cheeky method so that we can reuse the same array
+        const found: any[] = params.filter(p => p.localKey === name);
+        if (found != null && found.length > 0) {
+            const index = params.indexOf(found[0]);
+            params.splice(index, 1);
+        }
+    }
+    const param = { name, path, required };
+    params.push(param);
+
+    // merge mapped_parameters from parent if it has some
+    let parent = Object.getPrototypeOf(target);
+    while (parent != null) {
+        const protoParams: any[] = get_metadata(parent, "__values");
+        if (protoParams != null) {
+            protoParams.forEach(protoParam => {
+                // if we don't already have a parameter with the same name
+                if (!params.some(p => p.name === protoParam.name)) {
+                    params.push(protoParam);
+                }
+            });
+        }
+        parent = Object.getPrototypeOf(parent);
+    }
+
+    set_metadata(target, "__values", params);
+    return target;
+}
+
 export function declareSecret(target: any, name: string, uri: string) {
     let params = get_metadata(target, "__secrets");
     if (params == null) {
         params = [];
     } else {
-        // remove any that have the same name already (i.e. if folk are calling declareParameter)
+        // remove any that have the same name already (i.e. if folk are calling declareSecret)
         // use a cheeky method so that we can reuse the same array
         const found: any[] = params.filter(p => p.name === name);
         if (found != null && found.length > 0) {

--- a/src/internal/metadata/decoratorSupport.ts
+++ b/src/internal/metadata/decoratorSupport.ts
@@ -27,6 +27,12 @@ export interface Parameter extends BaseParameter {
     // readonly default?: string;
 }
 
+export interface BaseValue {
+    path: string;
+    required?: boolean;
+    type?: "string" | "number" | "boolean";
+}
+
 function set_metadata(obj: any, key: string, value: any) {
     let target = obj;
     if (obj.prototype !== undefined) {
@@ -129,12 +135,12 @@ export function declareMappedParameter(target: any, name: string, uri: string, r
     return target;
 }
 
-export function declareValue(target: any, name: string, path: string, required: boolean) {
+export function declareValue(target: any, name: string, value: BaseValue) {
     let params = get_metadata(target, "__values");
     if (params == null) {
         params = [];
     } else {
-        // remove any that have the same name already (i.e. if folk are calling declareConfig)
+        // remove any that have the same name already (i.e. if folk are calling declareValue)
         // use a cheeky method so that we can reuse the same array
         const found: any[] = params.filter(p => p.localKey === name);
         if (found != null && found.length > 0) {
@@ -142,16 +148,16 @@ export function declareValue(target: any, name: string, path: string, required: 
             params.splice(index, 1);
         }
     }
-    const param = { name, path, required };
+    const param = { name, value };
     params.push(param);
 
-    // merge mapped_parameters from parent if it has some
+    // merge values from parent if it has some
     let parent = Object.getPrototypeOf(target);
     while (parent != null) {
         const protoParams: any[] = get_metadata(parent, "__values");
         if (protoParams != null) {
             protoParams.forEach(protoParam => {
-                // if we don't already have a parameter with the same name
+                // if we don't already have a value with the same name
                 if (!params.some(p => p.name === protoParam.name)) {
                     params.push(protoParam);
                 }

--- a/src/internal/metadata/metadataReading.ts
+++ b/src/internal/metadata/metadataReading.ts
@@ -9,6 +9,7 @@ import {
     SecretDeclaration,
     ValueDeclaration,
 } from "../../metadata/automationMetadata";
+import { BaseValue } from "./decoratorSupport";
 import * as decorators from "./decoratorSupport";
 import {
     isCommandHandlerMetadata,
@@ -174,8 +175,9 @@ function valueMetadataFromInstance(r: any, prefix: string = ""): ValueDeclaratio
     const directValues = !!r && r.__values ? r.__values.map(mp =>
         ({
             name: prefix + mp.name,
-            path: mp.path,
-            required: mp.required !== false,
+            path: mp.value.path,
+            required: mp.value.required !== false,
+            type: mp.value.type ? mp.value.type : "string",
         })) : [];
     const nestedValues = _.flatten(Object.keys(r)
         .map(key => [key, r[key]])

--- a/src/internal/parameterPopulation.ts
+++ b/src/internal/parameterPopulation.ts
@@ -1,5 +1,8 @@
 import * as _ from "lodash";
+import { automationClientInstance } from "../automationClient";
+import { Configuration } from "../configuration";
 import {
+    AutomationMetadata,
     Chooser,
     CommandHandlerMetadata,
     FreeChoices,
@@ -21,6 +24,18 @@ export function populateParameters(instanceToPopulate: any, hm: CommandHandlerMe
             if (parameter) {
                 _.update(instanceToPopulate, parameter.name, () => computeValue(parameter, arg));
             }
+        }
+    });
+}
+
+export function populateValues(instanceToPopulate: any, am: AutomationMetadata, configuration: Configuration) {
+    (am.values || []).forEach(v => {
+        const configValue = _.get(configuration, v.path);
+        if (!configValue && v.required) {
+            throw new Error(`Required @Value '${v.path}' in '${
+                instanceToPopulate.constructor.name}' is not available in configuration`);
+        } else {
+            _.update(instanceToPopulate, v.name, () => configValue);
         }
     });
 }

--- a/src/internal/parameterPopulation.ts
+++ b/src/internal/parameterPopulation.ts
@@ -43,19 +43,16 @@ export function populateValues(instanceToPopulate: any, am: AutomationMetadata, 
 function computeValue(parameter: { name: string, type?: ParameterType }, value: any) {
     // Convert type if necessary
     switch (parameter.type) {
+        case "string":
         case undefined:
             // It's a string. Keep the value the same
-            value = value;
             break;
         case FreeChoices:
             // It's a string array. Keep the value the same
-            value = value;
             break;
         case "boolean":
-            if (typeof value === "boolean") {
-                value = value;
-            } else {
-                value = value === "true";
+            if (typeof value !== "boolean") {
+                value = value === "true" || value === "yes" || value === "1";
             }
             break;
         case "number":
@@ -72,14 +69,10 @@ function computeValue(parameter: { name: string, type?: ParameterType }, value: 
                 if (typeof value !== "string") {
                     throw new Error(`Parameter '${parameter.name}' has array value, but should be string`);
                 }
-                // Treat as a string
-                value = value;
             } else {
                 if (typeof value.value === "string") {
                     throw new Error(`Parameter '${parameter.name}' has string value, but should be array`);
                 }
-                // It's an array
-                value = value;
             }
             break;
     }

--- a/src/metadata/automationMetadata.ts
+++ b/src/metadata/automationMetadata.ts
@@ -86,6 +86,15 @@ export interface AutomationMetadata {
     name: string;
     description: string;
     tags?: Tag[];
+    values?: ValueDeclaration[];
+}
+
+export interface ValueDeclaration {
+
+    name: string;
+    path: string;
+    root: string;
+    required: boolean;
 }
 
 export interface MappedParameterDeclaration {

--- a/src/metadata/automationMetadata.ts
+++ b/src/metadata/automationMetadata.ts
@@ -95,6 +95,7 @@ export interface ValueDeclaration {
     path: string;
     root: string;
     required: boolean;
+    type: boolean;
 }
 
 export interface MappedParameterDeclaration {

--- a/src/onCommand.ts
+++ b/src/onCommand.ts
@@ -10,6 +10,7 @@ import {
     Parameter,
     SecretDeclaration,
     Tag,
+    ValueDeclaration,
 } from "./metadata/automationMetadata";
 import { registerCommand } from "./scan";
 import { Maker, toFactory } from "./util/constructionUtils";
@@ -58,6 +59,7 @@ class FunctionWrappingCommandHandler<P> implements SelfDescribingHandleCommand<P
     public mapped_parameters: MappedParameterDeclaration[];
 
     public secrets?: SecretDeclaration[];
+    public values?: ValueDeclaration[];
     public intent?: string[];
     public tags?: Tag[];
 
@@ -65,14 +67,15 @@ class FunctionWrappingCommandHandler<P> implements SelfDescribingHandleCommand<P
                 public description: string,
                 private h: OnCommand<P>,
                 private parametersFactory: Maker<P>,
-        // tslint:disable-next-line:variable-name
+                // tslint:disable-next-line:variable-name
                 private _tags: string | string[] = [],
-        // tslint:disable-next-line:variable-name
+                // tslint:disable-next-line:variable-name
                 private _intent: string | string[] = []) {
         const newParamInstance = this.freshParametersInstance();
         const md = metadataFromInstance(newParamInstance) as CommandHandlerMetadata;
         this.parameters = md.parameters;
         this.mapped_parameters = md.mapped_parameters;
+        this.values = md.values;
         this.secrets = md.secrets;
         this.intent = toStringArray(_intent);
         this.tags = toStringArray(_tags).map(t => ({ name: t, description: t }));

--- a/src/server/BuildableAutomationServer.ts
+++ b/src/server/BuildableAutomationServer.ts
@@ -1,7 +1,11 @@
 import * as _ from "lodash";
 
 import * as stringify from "json-stringify-safe";
-import { AutomationServerOptions } from "../configuration";
+import { automationClientInstance } from "../automationClient";
+import {
+    AutomationServerOptions,
+    Configuration,
+} from "../configuration";
 import { ApolloGraphClient } from "../graph/ApolloGraphClient";
 import { HandleCommand } from "../HandleCommand";
 import {
@@ -22,7 +26,10 @@ import {
 } from "../internal/invoker/Payload";
 import { Automations, isCommandHandlerMetadata } from "../internal/metadata/metadata";
 import { metadataFromInstance } from "../internal/metadata/metadataReading";
-import { populateParameters } from "../internal/parameterPopulation";
+import {
+    populateParameters,
+    populateValues,
+} from "../internal/parameterPopulation";
 import { logger } from "../internal/util/logger";
 import { toStringArray } from "../internal/util/string";
 import {
@@ -163,6 +170,7 @@ export class BuildableAutomationServer extends AbstractAutomationServer {
                                                                invocation: CommandInvocation,
                                                                ctx: HandlerContext): Promise<HandlerResult> {
         populateParameters(params, md, invocation.args);
+        populateValues(params, md, this.opts );
         this.populateMappedParameters(params, md, invocation);
         this.populateSecrets(params, md, invocation.secrets);
 
@@ -197,6 +205,7 @@ export class BuildableAutomationServer extends AbstractAutomationServer {
                                             e: EventFired<any>,
                                             ctx: HandlerContext): Promise<HandlerResult> {
         this.populateSecrets(h, metadata, e.secrets);
+        populateValues(h, metadata, this.opts);
         const handlerResult = h.handle(e, this.enrichContext(ctx), h);
         if (!handlerResult) {
             return SuccessPromise;

--- a/test/atomist.config.ts
+++ b/test/atomist.config.ts
@@ -82,10 +82,10 @@ export const configuration: Configuration = {
         // workers: 2,
     },
     postProcessors: [
-        config => {
+        /*config => {
             config.custom = { test: "123456" };
             return Promise.resolve(config);
-        },
+        },*/
     ],
     logging: {
         level: "debug",

--- a/test/atomist.config.ts
+++ b/test/atomist.config.ts
@@ -82,10 +82,10 @@ export const configuration: Configuration = {
         // workers: 2,
     },
     postProcessors: [
-        /*config => {
+        config => {
             config.custom = { test: "123456" };
             return Promise.resolve(config);
-        },*/
+        },
     ],
     logging: {
         level: "debug",

--- a/test/command/HelloWorld.ts
+++ b/test/command/HelloWorld.ts
@@ -3,6 +3,7 @@ import {
     MappedParameter,
     MappedParameters,
     Parameter,
+    Value,
 } from "../../src/decorators";
 import { HandleCommand } from "../../src/HandleCommand";
 import { HandlerContext } from "../../src/HandlerContext";

--- a/test/event/HelloIssue.ts
+++ b/test/event/HelloIssue.ts
@@ -3,6 +3,7 @@ import {
     EventHandler,
     Secret,
     Secrets,
+    Value,
 } from "../../src/decorators";
 import {
     EventFired,
@@ -36,6 +37,9 @@ export class HelloIssue implements HandleEvent<any> {
 
     @Secret(Secrets.OrgToken)
     public githubToken: string;
+
+    @Value("http.port")
+    public port: number;
 
     public handle(e: EventFired<any>, ctx: HandlerContext): Promise<HandlerResult> {
 

--- a/test/internal/invoker/functionStyleCommandHandlerTest.ts
+++ b/test/internal/invoker/functionStyleCommandHandlerTest.ts
@@ -15,7 +15,8 @@ describe("function style command handler invocation", () => {
                 },
             },
         } as HandlerContext;
-        const s = new BuildableAutomationServer({ name: "foobar", version: "1.0.0", teamIds: ["bar"], keywords: [] });
+        const s = new BuildableAutomationServer(
+            { name: "foobar", version: "1.0.0", teamIds: ["bar"], keywords: [], custom: { http: { port: 1111 } } });
         s.fromCommandHandler(addAtomistSpringAgent);
 
         const payload: CommandInvocation = {

--- a/test/internal/metadata/addAtomistSpringAgent.ts
+++ b/test/internal/metadata/addAtomistSpringAgent.ts
@@ -1,4 +1,10 @@
-import { MappedParameter, Parameter, Parameters, Secret } from "../../../src/decorators";
+import {
+    MappedParameter,
+    Parameter,
+    Parameters,
+    Secret,
+    Value,
+} from "../../../src/decorators";
 import { HandleCommand } from "../../../src/HandleCommand";
 import { commandHandlerFrom } from "../../../src/onCommand";
 import { succeed } from "../../../src/operations/support/contextUtils";
@@ -20,6 +26,9 @@ export class AddAtomistSpringAgentParams {
 
     @Secret("atomist://some_secret")
     public someSecret: string;
+
+    @Value("custom.http.port", true)
+    public port: number;
 }
 
 // Note we need an explicit type annotation here to avoid an error

--- a/test/internal/metadata/addAtomistSpringAgent.ts
+++ b/test/internal/metadata/addAtomistSpringAgent.ts
@@ -27,7 +27,7 @@ export class AddAtomistSpringAgentParams {
     @Secret("atomist://some_secret")
     public someSecret: string;
 
-    @Value("custom.http.port", true)
+    @Value({ path: "custom.http.port", required: true })
     public port: number;
 }
 

--- a/test/internal/metadata/classStyleMetadataReadingTest.ts
+++ b/test/internal/metadata/classStyleMetadataReadingTest.ts
@@ -213,6 +213,60 @@ describe("class style metadata reading", () => {
 
     });
 
+    it("should handle @Value with boolean type conversation", () => {
+        const h = new HasBooleanValue();
+        const md = metadataFromInstance(h) as CommandHandlerMetadata;
+        const mp = md.values[0];
+        assert(mp.required === true);
+        assert(mp.name === "foo");
+        assert(mp.path === "custom.foo");
+
+        const config: Configuration = {
+            custom: {
+                foo: "true",
+            },
+        };
+
+        populateValues(h, md, config);
+        assert.equal(h.foo, true);
+    });
+
+    it("should handle @Value with number type conversation", () => {
+        const h = new HasNumberValue();
+        const md = metadataFromInstance(h) as CommandHandlerMetadata;
+        const mp = md.values[0];
+        assert(mp.required === true);
+        assert(mp.name === "foo");
+        assert(mp.path === "custom.foo");
+
+        const config: Configuration = {
+            custom: {
+                foo: "10",
+            },
+        };
+
+        populateValues(h, md, config);
+        assert.equal(h.foo, 10);
+    });
+
+    it("should handle @Value with string type conversation", () => {
+        const h = new HasStringValue();
+        const md = metadataFromInstance(h) as CommandHandlerMetadata;
+        const mp = md.values[0];
+        assert(mp.required === true);
+        assert(mp.name === "foo");
+        assert(mp.path === "custom.foo");
+
+        const config: Configuration = {
+            custom: {
+                foo: 1,
+            },
+        };
+
+        populateValues(h, md, config);
+        assert.equal(h.foo, "1");
+    });
+
 });
 
 export class Superclass implements HandleCommand {
@@ -291,7 +345,7 @@ export class HasDefaultedBooleanParam implements HandleCommand {
     })
     public booleanParam: boolean = true;
 
-    @Value("teamIds", false)
+    @Value({ path: "teamIds", required: false })
     public teams: string[];
 
     public handle(context: HandlerContext): Promise<HandlerResult> {
@@ -435,6 +489,39 @@ export class NoDecoratorEventHandlerWithoutInterface implements HandleEvent<any>
 export class OptionalMappedParameter implements HandleCommand {
 
     @MappedParameter("lookup", false)
+    public foo: string;
+
+    public handle(context: HandlerContext): Promise<HandlerResult> {
+        throw new Error("not relevant");
+    }
+}
+
+@CommandHandler("description", "universal", "generator")
+export class HasBooleanValue implements HandleCommand {
+
+    @Value({ path: "custom.foo", type: "boolean" })
+    public foo: boolean;
+
+    public handle(context: HandlerContext): Promise<HandlerResult> {
+        throw new Error("not relevant");
+    }
+}
+
+@CommandHandler("description", "universal", "generator")
+export class HasNumberValue implements HandleCommand {
+
+    @Value({ path: "custom.foo", type: "number" })
+    public foo: number;
+
+    public handle(context: HandlerContext): Promise<HandlerResult> {
+        throw new Error("not relevant");
+    }
+}
+
+@CommandHandler("description", "universal", "generator")
+export class HasStringValue implements HandleCommand {
+
+    @Value({ path: "custom.foo", type: "string" })
     public foo: string;
 
     public handle(context: HandlerContext): Promise<HandlerResult> {

--- a/test/internal/metadata/eventMetadataReadingTest.ts
+++ b/test/internal/metadata/eventMetadataReadingTest.ts
@@ -1,15 +1,27 @@
 import "mocha";
+import { Configuration } from "../../../src";
 import { metadataFromInstance } from "../../../src/internal/metadata/metadataReading";
 
 import * as assert from "power-assert";
+import { populateValues } from "../../../src/internal/parameterPopulation";
 import { EventHandlerMetadata } from "../../../src/metadata/automationMetadata";
 import { HelloIssue } from "../../event/HelloIssue";
 
 describe("class style event metadata reading", () => {
 
     it("should extract metadataFromInstance from event handler", () => {
-        const md = metadataFromInstance(new HelloIssue()) as EventHandlerMetadata;
+        const h = new HelloIssue();
+        const md = metadataFromInstance(h) as EventHandlerMetadata;
         assert(md.subscriptionName === "HelloIssue");
+
+        const config: Configuration = {
+            http: {
+                port: 1111,
+            },
+        };
+
+        populateValues(h, md, config);
+        assert.equal(h.port, config.http.port);
     });
 
 });

--- a/test/internal/metadata/functionStyleMetadataReadingTest.ts
+++ b/test/internal/metadata/functionStyleMetadataReadingTest.ts
@@ -21,6 +21,9 @@ describe("function style metadata reading", () => {
         assert(md.secrets.length === 1);
         assert(md.secrets[0].name === "someSecret");
         assert(md.secrets[0].uri === "atomist://some_secret");
+        assert(md.values.length === 1);
+        assert(md.values[0].name === "port");
+        assert(md.values[0].path === "custom.http.port");
         assert.deepEqual(md.intent, ["add agent"]);
         assert.deepEqual(md.tags.map(t => t.name), ["atomist", "spring", "agent"]);
     });

--- a/test/scanTest.ts
+++ b/test/scanTest.ts
@@ -1,7 +1,7 @@
 import "mocha";
 import * as assert from "power-assert";
 
-import { findConfiguration, loadConfiguration } from "../src/configuration";
+import { loadConfiguration } from "../src/configuration";
 
 describe("scan", () => {
 


### PR DESCRIPTION
This allows us to inject values from the configuration object into command and/or event handlers. 

As an example:
```
interface DockerOptions {
   registry: string;
   user: string;
   password: string;
}

... 

@Value({ path: "docker", root: "custom", required: false })
public dockerOptions: DockerOptions;
```

with the following configuration: 
```
export const configuration: Configuration = {
   custom: {
     docker: {
       registry: "http://google.com",
       user: "something",
       password: "something else",
     },
   },
};
```

If access to configuration is needed from outside command or event handlers, there is now the following method: 

```
const dockerOptions = configurationValue<DockerOptions>("custom.docker");
```