### PR TITLE
Change default behavior for --install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 -   Reduce default websocket grace period to 10 seconds
+-   Default for `--install` command-line options is to install if the
+    node_modules directory does not exist
 
 ## [0.14.1][] - 2018-04-30
 

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -196,7 +196,8 @@ function execJs(opts: ExecOptions): number {
  * @return integer return value of command, 0 if command is successful
  */
 function execCmd(opts: ExecOptions): number {
-    if (opts.runInstall) {
+    if (opts.runInstall === true ||
+        (opts.runInstall !== false && !fs.existsSync(path.join(opts.cwd, "node_modules")))) {
         const installStatus = install(opts.cwd);
         if (installStatus !== 0) {
             return installStatus;

--- a/src/start.cli.ts
+++ b/src/start.cli.ts
@@ -20,6 +20,10 @@ import { CommandInvocation } from "./internal/invoker/Payload";
 
 const Package = "atomist";
 
+const compileDescribe = "Run 'npm run compile' before running";
+const installDescribe = "Run 'npm install' before running/compiling, default is to install if no " +
+    "'node_modules' directory exists";
+
 // tslint:disable-next-line:no-unused-expression
 yargs.completion("completion")
     .command(["execute <name>", "exec <name>", "cmd <name>"], "Run a command", ya => {
@@ -36,12 +40,11 @@ yargs.completion("completion")
             })
             .option("compile", {
                 default: true,
-                describe: "Run 'npm run compile' before running",
+                describe: compileDescribe,
                 type: "boolean",
             })
             .option("install", {
-                default: true,
-                describe: "Run 'npm install' before running/compiling",
+                describe: installDescribe,
                 type: "boolean",
             });
     }, argv => {
@@ -68,12 +71,11 @@ yargs.completion("completion")
             })
             .option("compile", {
                 default: true,
-                describe: "Run 'npm run compile' before starting",
+                describe: compileDescribe,
                 type: "boolean",
             })
             .option("install", {
-                default: true,
-                describe: "Run 'npm install' before starting/compiling",
+                describe: installDescribe,
                 type: "boolean",
             });
     }, argv => {
@@ -105,8 +107,7 @@ yargs.completion("completion")
                 type: "string",
             })
             .option("install", {
-                default: true,
-                describe: "Run 'npm install' before starting/compiling",
+                describe: installDescribe,
                 type: "boolean",
             });
     }, argv => {
@@ -125,8 +126,7 @@ yargs.completion("completion")
                 type: "string",
             })
             .option("install", {
-                default: true,
-                describe: "Run 'npm install' before starting/compiling",
+                describe: installDescribe,
                 type: "boolean",
             });
     }, argv => {


### PR DESCRIPTION
Rather than default to true, install will only be run if
its expected outputs, the node_modules, does not exist.
If the option or its negation is provided, the existence
of the output directory is immaterial.