### PR TITLE
Save SDM env vars to user config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 -   Default for `--install` command-line options is to install if the
     node_modules directory does not exist
 
+### Added
+
+-   The config command now probes environment for known SDM variables
+    and persists them to the user configuration
+
 ## [0.14.1][] - 2018-04-30
 
 [0.14.1]: https://github.com/atomist/automation-client-ts/compare/0.14.0...0.14.1

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -1,9 +1,15 @@
 import * as GitHubApi from "@octokit/rest";
 import * as inquirer from "inquirer";
 import * as stringify from "json-stringify-safe";
+import * as _ from "lodash";
 import * as os from "os";
+import * as path from "path";
 
-import { getUserConfig, writeUserConfig } from "../configuration";
+import {
+    getUserConfig,
+    userConfigPath,
+    writeUserConfig,
+} from "../configuration";
 import { obfuscateJson } from "../internal/util/string";
 
 const github = new GitHubApi();
@@ -42,11 +48,6 @@ export function cliAtomistConfig(argv: any): Promise<number> {
     if (!userConfig.teamIds) {
         userConfig.teamIds = [];
     }
-    if (userConfig.token && userConfig.teamIds.length > 0 && !argTeamId) {
-        console.log(`Existing configuration is valid (${stringify(userConfig, obfuscateJson)}) and no team ` +
-            `supplied, exiting`);
-        return Promise.resolve(0);
-    }
     if (argTeamId) {
         if (!userConfig.teamIds.includes(argTeamId)) {
             userConfig.teamIds.push(argTeamId);
@@ -54,15 +55,32 @@ export function cliAtomistConfig(argv: any): Promise<number> {
     }
 
     const questions: inquirer.Questions = [];
-    if (userConfig.teamIds.length < 1) {
-        questions.push({
-            type: "input",
-            name: "teamId",
-            message: "Team ID",
-            validate: value => true,
-        });
+
+    const teamsQuestion: inquirer.Question = {
+        type: "input",
+        name: "teamIds",
+        message: "Team IDs (space delimited)",
+        validate: value => {
+            if (!/\S/.test(value) && userConfig.teamIds.length < 1) {
+                return `The list of team IDs you entered is empty`;
+            }
+            return true;
+        },
+    };
+    if (userConfig.teamIds.length > 0) {
+        teamsQuestion.default = userConfig.teamIds.join(" ");
     }
+    questions.push(teamsQuestion);
+
     if (!userConfig.token) {
+        console.log(`
+As part of the Atomist configuration, we need to create a GitHub
+personal access token for you that will be used to authenticate with
+the Atomist API.  The personal access token will have "read:org" and
+"repo" scopes, be labeled as being for the "Atomist API", and will be
+written to a file on your local machine.  Atomist does not retain the
+token nor your GitHub username and password.
+`);
         if (!argGitHubUser) {
             questions.push({
                 type: "input",
@@ -121,23 +139,257 @@ export function cliAtomistConfig(argv: any): Promise<number> {
                 },
             } as any as inquirer.Question);
         }
+    } else {
+        console.log(`
+Your Atomist user configuration already has an access token.
+To generate a new token, remove the existing token from
+'${userConfigPath()}'
+and run \`atomist config\` again.
+`);
     }
 
-    if (questions.length > 0) {
-        console.log(`
-As part of the initial Atomist configuration, we need to create a
-GitHub personal access token for you that will be used to authenticate
-with the Atomist API.  The personal access token will have "read:org"
-scope, be labeled as being for the "Atomist API", and will be written
-to a file on your local machine.  Atomist does not retain the token
-nor your GitHub username and password.
-`);
+    if (process.env.ATOMIST_DOCKER_REGISTRY || process.env.ATOMIST_DOCKER_USER ||
+        process.env.ATOMIST_DOCKER_PASSWORD) {
+        const dockerRegistry: inquirer.Question = {
+            type: "input",
+            name: "dockerRegistry",
+            message: "Docker Registry Host",
+            validate: value => {
+                if (!/\S/.test(value) && !process.env.ATOMIST_DOCKER_REGISTRY) {
+                    return `The Docker registry host you entered is empty`;
+                }
+                return true;
+            },
+        };
+        if (process.env.ATOMIST_DOCKER_REGISTRY) {
+            dockerRegistry.default = process.env.ATOMIST_DOCKER_REGISTRY;
+        }
+        const dockerUser: inquirer.Question = {
+            type: "input",
+            name: "dockerUser",
+            message: "Docker Registry Username",
+            validate: value => {
+                if (!/\S/.test(value) && !process.env.ATOMIST_DOCKER_USER) {
+                    return `The Docker registry username you entered is empty`;
+                }
+                return true;
+            },
+        };
+        if (process.env.ATOMIST_DOCKER_USER) {
+            dockerUser.default = process.env.ATOMIST_DOCKER_USER;
+        }
+        const dockerPassword: inquirer.Question = {
+            type: "password",
+            name: "dockerPassword",
+            message: "Docker Registry Password",
+            validate: value => {
+                if (!/\S/.test(value) && !process.env.ATOMIST_DOCKER_PASSWORD) {
+                    return `The Docker registry password you entered is empty`;
+                }
+                return true;
+            },
+        };
+        if (process.env.ATOMIST_DOCKER_PASSWORD) {
+            dockerPassword.default = process.env.ATOMIST_DOCKER_PASSWORD;
+        }
+        questions.push(dockerRegistry, dockerUser, dockerPassword);
+    }
+
+    if (process.env.PCF_API || process.env.PCF_ORG || process.env.PCF_SPACE_STAGING ||
+        process.env.PCF_SPACE_PRODUCTION || process.env.PIVOTAL_USER || process.env.PIVOTAL_PASSWORD) {
+        const cfUser: inquirer.Question = {
+            type: "input",
+            name: "cfUser",
+            message: "Cloud Foundry Username",
+            validate: value => {
+                if (!/\S/.test(value) && !process.env.PIVOTAL_USER) {
+                    return `The Cloud Foundry username you entered is empty`;
+                }
+                return true;
+            },
+        };
+        if (process.env.PIVOTAL_USER) {
+            cfUser.default = process.env.PIVOTAL_USER;
+        }
+        const cfPassword: inquirer.Question = {
+            type: "password",
+            name: "cfPassword",
+            message: "Cloud Foundry Password",
+            validate: value => {
+                if (!/\S/.test(value) && !process.env.PIVOTAL_PASSWORD) {
+                    return `The Cloud Foundry password you entered is empty`;
+                }
+                return true;
+            },
+        };
+        if (process.env.PIVOTAL_PASSWORD) {
+            cfPassword.default = process.env.PIVOTAL_PASSWORD;
+        }
+        const cfOrg: inquirer.Question = {
+            type: "input",
+            name: "cfOrg",
+            message: "Cloud Foundry Org",
+            validate: value => {
+                if (!/\S/.test(value) && !process.env.PCF_ORG) {
+                    return `The Cloud Foundry Org you entered is empty`;
+                }
+                return true;
+            },
+        };
+        if (process.env.PCF_ORG) {
+            cfOrg.default = process.env.PCF_ORG;
+        }
+        const cfSpaceStaging: inquirer.Question = {
+            type: "input",
+            name: "cfSpaceStaging",
+            message: "Cloud Foundry Staging Space",
+            validate: value => {
+                if (!/\S/.test(value) && !process.env.PCF_SPACE_STAGING) {
+                    return `The Cloud Foundry Space you entered is empty`;
+                }
+                return true;
+            },
+        };
+        if (process.env.PCF_SPACE_STAGING) {
+            cfOrg.default = process.env.PCF_SPACE_STAGING;
+        }
+        const cfSpaceProd: inquirer.Question = {
+            type: "input",
+            name: "cfSpaceProd",
+            message: "Cloud Foundry Production Space",
+            validate: value => {
+                if (!/\S/.test(value) && !process.env.PCF_SPACE_PRODUCTION) {
+                    return `The Cloud Foundry Space you entered is empty`;
+                }
+                return true;
+            },
+        };
+        if (process.env.PCF_SPACE_PRODUCTION) {
+            cfOrg.default = process.env.PCF_SPACE_PRODUCTION;
+        }
+        const cfApi: inquirer.Question = {
+            type: "input",
+            name: "cfApi",
+            message: "Cloud Foundry API endpoint",
+            validate: value => {
+                if (!/\S/.test(value) && !process.env.PCF_API) {
+                    return `The Cloud Foundry API enpoint you entered is empty`;
+                }
+                return true;
+            },
+        };
+        if (process.env.PCF_API) {
+            cfApi.default = process.env.PCF_API;
+        } else {
+            cfApi.default = "https://api.run.pivotal.io";
+        }
+        questions.push(cfUser, cfPassword, cfOrg, cfSpaceStaging, cfSpaceProd, cfApi);
+    }
+
+    if (process.env.ATOMIST_NPM) {
+        const npm: inquirer.Question = {
+            type: "input",
+            name: "npm",
+            message: "NPM configuration (JSON stringified)",
+            validate: value => {
+                if (!/\S/.test(value) && !process.env.ATOMIST_NPM) {
+                    return `The NPM configuration you entered is empty`;
+                }
+                return true;
+            },
+            default: process.env.ATOMIST_NPM,
+        };
+        questions.push(npm);
+    }
+
+    if (process.env.USE_CHECKSTYLE || process.env.CHECKSTYLE_PATH) {
+        const checkstyle: inquirer.Question = {
+            type: "confirm",
+            name: "checkstyle",
+            message: "Use checkstyle?",
+        };
+        if (process.env.USE_CHECKSTYLE) {
+            checkstyle.default = process.env.USE_CHECKSTYLE;
+        }
+        const checkstylePath: inquirer.Question = {
+            type: "input",
+            name: "checkstylePath",
+            message: "Absolute path to checkstyle jar",
+            validate: value => {
+                if (!value && !process.env.CHECKSTYLE_PATH) {
+                    return `You must provide a path to the checkstyle jar`;
+                }
+                if (value && !/\.jar$/i.test(value)) {
+                    return `The path to the checkstyle jar must end with '.jar'`;
+                }
+                return true;
+            },
+        };
+        if (process.env.CHECKSTYLE_PATH) {
+            checkstylePath.default = process.env.CHECKSTYLE_PATH;
+        }
+        questions.push(checkstyle, checkstylePath);
     }
 
     return inquirer.prompt(questions)
         .then(answers => {
-            if (answers.teamId) {
-                userConfig.teamIds.push(answers.teamId);
+            if (answers.teamIds) {
+                userConfig.teamIds = (answers.teamIds as string).split(/\s+/);
+            }
+
+            if (answers.dockerRegistry) {
+                const dockerConf = {
+                    registry: answers.dockerRegistry,
+                    user: answers.dockerUser,
+                    password: answers.dockerPassword,
+                };
+                if (userConfig.docker) {
+                    _.merge(userConfig.docker, dockerConf);
+                } else {
+                    userConfig.docker = dockerConf;
+                }
+            }
+
+            if (answers.cfUser) {
+                const cfConf = {
+                    user: answers.cfUser,
+                    password: answers.cfPassword,
+                    org: answers.cfOrg,
+                    spaceStaging: answers.cfSpaceStaging,
+                    spaceProduction: answers.cfSpaceProd,
+                    api: answers.cfApi,
+                };
+                if (userConfig.cloudFoundry) {
+                    _.merge(userConfig.cloudFoundry, cfConf);
+                } else {
+                    userConfig.cloudFoundry = cfConf;
+                }
+            }
+
+            if (answers.npm) {
+                try {
+                    const npmConf = JSON.parse(answers.npm);
+                    if (userConfig.npm) {
+                        _.merge(userConfig.npm, npmConf);
+                    } else {
+                        userConfig.npm = npmConf;
+                    }
+                } catch (e) {
+                    e.message = `Failed to parse NPM configuration as JSON: ${e.message}`;
+                    return Promise.reject(e);
+                }
+            }
+
+            if (answers.checkstylePath) {
+                const checkstyleConf = {
+                    enable: answers.checkstyle,
+                    path: answers.checkstylePath,
+                };
+                if (userConfig.checkstyle) {
+                    _.merge(userConfig.checkstyle, checkstyleConf);
+                } else {
+                    userConfig.checkstyle = checkstyleConf;
+                }
             }
 
             if (!userConfig.token) {

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -361,7 +361,7 @@ function userConfigDir(): string {
 /**
  * Return user automation client configuration path.
  */
-function userConfigPath(): string {
+export function userConfigPath(): string {
     const clientConfigFile = "client.config.json";
     return p.join(userConfigDir(), clientConfigFile);
 }


### PR DESCRIPTION
To aid transition from environment variables to custom configuration,
a more secure solution, have `atomist config` probe for known SDM
environment variables and store them in the custom property of the
user configuration.

This will always prompt for team when `atomist config` is run.