### PR TITLE
Add options to GitProject.push()

### DIFF
--- a/src/project/git/GitProject.ts
+++ b/src/project/git/GitProject.ts
@@ -5,6 +5,17 @@ import { Configurable } from "./Configurable";
 import { GitStatus } from "./gitStatus";
 
 /**
+ * Git push options.  See git-push(1) for more information.
+ */
+export interface GitPushOptions {
+    follow_tags?: boolean;
+    force?: boolean;
+    force_with_lease?: boolean | string;
+    quiet?: boolean;
+    verbose?: boolean;
+}
+
+/**
  * Local project using git. Provides the ability to perform git operations
  * such as commit, and to set and push to a remote.
  */
@@ -22,7 +33,7 @@ export interface GitProject extends LocalProject, Configurable {
     init(): Promise<ActionResult<this>>;
 
     /**
-     * get some status information
+     * Get some status information
      */
     gitStatus(): Promise<GitStatus>;
 
@@ -86,7 +97,7 @@ export interface GitProject extends LocalProject, Configurable {
     /**
      * Push to the remote.
      */
-    push(): Promise<ActionResult<this>>;
+    push(options?: GitPushOptions): Promise<ActionResult<this>>;
 
     /**
      * Create a new branch and switch to it.

--- a/test/project/git/GitCommandGitProjectTest.ts
+++ b/test/project/git/GitCommandGitProjectTest.ts
@@ -1,0 +1,85 @@
+import "mocha";
+import * as assert from "power-assert";
+
+import { GitCommandGitProject } from "../../../src/project/git/GitCommandGitProject";
+import { InMemoryProject } from "../../../src/project/mem/InMemoryProject";
+import { Project } from "../../../src/project/Project";
+
+describe("GitCommandGitProject", () => {
+
+    describe("push", () => {
+
+        const p = InMemoryProject.of();
+        (p as any).baseDir = "DRAM";
+        (p as any).id = {
+            sha: "master",
+        };
+        const c = { token: "blah" };
+        const gp = GitCommandGitProject.fromProject(p, c);
+
+        it("should execute a clean push", async () => {
+            let pushCmd: string;
+            (gp as any).runCommandInCurrentWorkingDirectory = (cmd: string): Promise<typeof gp> => {
+                pushCmd = cmd;
+                return Promise.resolve(gp);
+            };
+            await gp.push();
+            assert(pushCmd === "git push --set-upstream origin master");
+        });
+
+        it("should execute a force push", async () => {
+            let pushCmd: string;
+            (gp as any).runCommandInCurrentWorkingDirectory = (cmd: string): Promise<typeof gp> => {
+                pushCmd = cmd;
+                return Promise.resolve(gp);
+            };
+            await gp.push({ force: true });
+            assert(pushCmd === "git push --force --set-upstream origin master");
+        });
+
+        it("should be quiet and not verbose", async () => {
+            let pushCmd: string;
+            (gp as any).runCommandInCurrentWorkingDirectory = (cmd: string): Promise<typeof gp> => {
+                pushCmd = cmd;
+                return Promise.resolve(gp);
+            };
+            await gp.push({ quiet: true, verbose: false });
+            assert(pushCmd === "git push --quiet --no-verbose --set-upstream origin master");
+        });
+
+        it("should be treat --force-with-lease as a boolean", async () => {
+            let pushCmd: string;
+            (gp as any).runCommandInCurrentWorkingDirectory = (cmd: string): Promise<typeof gp> => {
+                pushCmd = cmd;
+                return Promise.resolve(gp);
+            };
+            await gp.push({ force_with_lease: true });
+            assert(pushCmd === "git push --force-with-lease --set-upstream origin master");
+        });
+
+        it("should be treat --force-with-lease as a string", async () => {
+            let pushCmd: string;
+            (gp as any).runCommandInCurrentWorkingDirectory = (cmd: string): Promise<typeof gp> => {
+                pushCmd = cmd;
+                return Promise.resolve(gp);
+            };
+            await gp.push({ force_with_lease: "master" });
+            assert(pushCmd === "git push --force-with-lease=master --set-upstream origin master");
+        });
+
+        it("should push to the provided remote", async () => {
+            let pushCmd: string;
+            const gh = GitCommandGitProject.fromProject(p, c);
+            gh.branch = "gh-pages";
+            gh.remote = "github";
+            (gh as any).runCommandInCurrentWorkingDirectory = (cmd: string): Promise<typeof gh> => {
+                pushCmd = cmd;
+                return Promise.resolve(gp);
+            };
+            await gh.push({ force: true });
+            assert(pushCmd === "git push --force github gh-pages");
+        });
+
+    });
+
+});


### PR DESCRIPTION
Allow --follow-tags, --force, --force-with-lease, --quiet, and
--verbose options.

Towards atomist/sdm#378