### PR TITLE
Add support for SDL ingesters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomist/automation-client",
-  "version": "0.16.1",
+  "version": "0.17.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomist/automation-client",
-  "version": "0.16.1",
+  "version": "0.17.0",
   "description": "Atomist automation client for running command and event handlers",
   "author": "Atomist, Inc.",
   "license": "SEE LICENSE IN LICENSE",

--- a/src/automationClient.ts
+++ b/src/automationClient.ts
@@ -67,7 +67,7 @@ export class AutomationClient {
         return this;
     }
 
-    public withIngester(ingester: Ingester): AutomationClient {
+    public withIngester(ingester: Ingester | string): AutomationClient {
         this.automations.registerIngester(ingester);
         return this;
     }
@@ -216,7 +216,9 @@ export function automationClient(configuration: Configuration): AutomationClient
         client.withEventHandler(e);
     });
     configuration.ingesters.forEach(e => {
-        if ((e as any).build) {
+        if (typeof e === "string") {
+            client.withIngester(e as string);
+        } else  if ((e as any).build) {
             client.withIngester((e as IngesterBuilder).build());
         } else {
             client.withIngester(e as Ingester);

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -271,7 +271,7 @@ export interface Configuration extends AutomationServerOptions {
      */
     events?: Array<Maker<HandleEvent<any>>>;
     /** Custom event ingester */
-    ingesters?: Array<Ingester | IngesterBuilder>;
+    ingesters?: Array<Ingester | IngesterBuilder | string>;
     /** Log and metric sinks */
     listeners?: AutomationEventListener[];
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,9 +47,10 @@ export { GraphQL };
 export { logger } from "./internal/util/logger";
 
 export {
-    type,
+    buildEnum,
+    buildIngester,
+    buildType,
     IngesterBuilder,
-    ingester,
 } from "./ingesters";
 
 export { AutomationEventListener } from "./server/AutomationEventListener";
@@ -64,6 +65,3 @@ export {
 export { LogHandler } from "./internal/transport/OnLog";
 
 export { automationClientInstance } from "./globals";
-
-// causes mocha tests in dependent projects to not exist cleanly
-// export { automationClientInstance } from "./automationClient";

--- a/src/ingesters.ts
+++ b/src/ingesters.ts
@@ -306,18 +306,8 @@ export class EnumBuilder {
  * @param {string | TypeBuilder} rootType
  * @returns {IngesterBuilder}
  */
-export function ingester(rootType: string | TypeBuilder): IngesterBuilder {
+export function buildIngester(rootType: string | TypeBuilder): IngesterBuilder {
     return new IngesterBuilder(rootType);
-}
-
-/**
- * Create a TypeBuilder for the provided name
- * @param {string} name
- * @returns {TypeBuilder}
- * Deprecated
- */
-export function type(name: string): TypeBuilder {
-    return new TypeBuilder(name);
 }
 
 /**

--- a/src/internal/graph/graphQL.ts
+++ b/src/internal/graph/graphQL.ts
@@ -166,6 +166,24 @@ export interface MutationOptions {
 }
 
 /**
+ * see src/graph/graphQL.ts
+ */
+export function ingester(options: IngesterOptions): string {
+
+    const path = options.path;
+    const name = options.name;
+    const pathToCallingFunction = options.moduleDir;
+
+    return locateAndLoadGraphql({ path, name }, "ingester", pathToCallingFunction);
+}
+
+export interface IngesterOptions {
+    name?: string;
+    path?: string;
+    moduleDir?: string;
+}
+
+/**
  * Extract operationName from the provided query or subscription
  * @param {string} q
  * @returns {string}

--- a/src/server/BuildableAutomationServer.ts
+++ b/src/server/BuildableAutomationServer.ts
@@ -75,7 +75,7 @@ export class BuildableAutomationServer extends AbstractAutomationServer {
 
     private eventHandlers: EventHandlerRegistration[] = [];
 
-    private ingesters: Ingester[] = [];
+    private ingesters: Array<Ingester | string> = [];
 
     constructor(public opts: AutomationServerOptions,
                 private fallbackSecretResolver: SecretResolver = new NodeConfigSecretResolver()) {

--- a/test/atomist.config.ts
+++ b/test/atomist.config.ts
@@ -1,11 +1,4 @@
 import { Configuration } from "../src/configuration";
-import {
-    buildEnum,
-    buildType,
-    ingester,
-    IngesterBuilder,
-    type,
-} from "../src/ingesters";
 import { FileMessageTest } from "./command/FileMessageTest";
 import { HelloWorld } from "./command/HelloWorld";
 import { MessageTest } from "./command/MessageTest";
@@ -40,13 +33,16 @@ export const configuration: Configuration = {
     ingesters: [
         // CircleCIPayload,
         // GitLabPushPayload,
-        ingester("HelloWorld")
+        /* buildIngester("HelloWorld")
             .withType(buildType("HelloWorldPerson").withStringField("name", "Name of the person"))
             .withEnum(buildEnum("Urgency", ["high", "low", "normal"], "How important is your message"))
             .withType(buildType("HelloWorld")
                 .withEnumField("urgency", "Urgency", "Field description")
                 .withObjectField("sender", "HelloWorldPerson", "sender desc", ["name"])
-                .withObjectField("recipient", "HelloWorldPerson", "recipient desc", ["name"])),
+                .withObjectField("recipient", "HelloWorldPerson", "recipient desc", ["name"])),*/
+        // fs.readFileSync(p.join(appRoot.path, "test", "graphql", "ingester", "helloWorld.graphql")).toString(),
+        // fs.readFileSync(p.join(appRoot.path, "test", "graphql", "ingester", "sdmGoal.graphql")).toString(),
+        // ingester("helloWorld"),
     ],
     ws: {
         enabled: true,
@@ -99,7 +95,7 @@ export const configuration: Configuration = {
             level: "debug",
         },
         logEvents: {
-            enabled: true,
+            enabled: false,
         },
     },
 };

--- a/test/graphql/ingester/helloWorld.graphql
+++ b/test/graphql/ingester/helloWorld.graphql
@@ -1,0 +1,15 @@
+type HelloWorld @rootType {
+    sender: HelloWorldPerson!
+    recipient(name: String!): HelloWorldPerson!
+    urgency: Urgency!
+}
+
+type HelloWorldPerson {
+    name: String!
+}
+
+enum Urgency {
+    HIGH,
+    LOW,
+    NORMAL
+}

--- a/test/graphql/ingester/sdmGoal.graphql
+++ b/test/graphql/ingester/sdmGoal.graphql
@@ -1,0 +1,4 @@
+type SdmGoalTest @rootType {
+    sha: String!
+    commit: Commit @linkTo(queryName: "commitBySha", variables: [{name: "sha", path: "$.sha"}])
+}

--- a/test/ingestersTest.ts
+++ b/test/ingestersTest.ts
@@ -2,15 +2,15 @@ import "mocha";
 import * as assert from "power-assert";
 import {
     buildEnum,
-    ingester,
-    type,
+    buildIngester,
+    buildType,
 } from "../src/ingesters";
 
 describe("ingesters", () => {
 
     it("should create simple root type with no field", () => {
-        const barType = type("bar");
-        const barIngester = ingester(barType).build();
+        const barType = buildType("bar");
+        const barIngester = buildIngester(barType).build();
         assert.deepEqual(barIngester, {
             root_type: "bar",
             types: [{
@@ -22,8 +22,8 @@ describe("ingesters", () => {
     });
 
     it("should create simple root type with one string field", () => {
-        const barType = type("bar").withStringField("poo");
-        const barIngester = ingester(barType).build();
+        const barType = buildType("bar").withStringField("poo");
+        const barIngester = buildIngester(barType).build();
         assert.deepStrictEqual(barIngester, {
             root_type: "bar",
             types: [{
@@ -42,8 +42,8 @@ describe("ingesters", () => {
 
     it("should create simple root type with one enum field", () => {
         const enumType = buildEnum("Color", ["red", "black", "blue"]);
-        const barType = type("bar").withEnumField("color", "Color");
-        const barIngester = ingester(barType).withEnum(enumType).build();
+        const barType = buildType("bar").withEnumField("color", "Color");
+        const barIngester = buildIngester(barType).withEnum(enumType).build();
         assert.deepEqual(barIngester, {
             root_type: "bar",
             types: [{
@@ -72,8 +72,8 @@ describe("ingesters", () => {
     });
 
     it("should create simple root type with two fields", () => {
-        const barType = type("bar").withStringField("poo").withIntField("puu");
-        const barIngester = ingester(barType).build();
+        const barType = buildType("bar").withStringField("poo").withIntField("puu");
+        const barIngester = buildIngester(barType).build();
         assert.deepEqual(barIngester, {
             root_type: "bar",
             types: [{
@@ -97,9 +97,9 @@ describe("ingesters", () => {
     });
 
     it("should create simple root type with an object field", () => {
-        const fooType = type("foo").withStringField("fuu");
-        const barType = type("bar").withObjectField("foo", fooType);
-        const barIngester = ingester(barType).withType(fooType).build();
+        const fooType = buildType("foo").withStringField("fuu");
+        const barType = buildType("bar").withObjectField("foo", fooType);
+        const barIngester = buildIngester(barType).withType(fooType).build();
         assert.deepEqual(barIngester, {
             root_type: "bar",
             types: [{
@@ -127,10 +127,10 @@ describe("ingesters", () => {
     });
 
     it("should create root type with two fields and another type", () => {
-        const fooType = type("foo").withBooleanField("fuu").withListScalarField("nums", "Int");
-        const barType = type("bar").withStringField("poo")
+        const fooType = buildType("foo").withBooleanField("fuu").withListScalarField("nums", "Int");
+        const barType = buildType("bar").withStringField("poo")
             .withFloatField("puu").withListObjectField("foos", fooType);
-        const barIngester = ingester(barType).withType(fooType).build();
+        const barIngester = buildIngester(barType).withType(fooType).build();
         assert.deepEqual(barIngester, {
             root_type: "bar",
             types: [{
@@ -182,9 +182,9 @@ describe("ingesters", () => {
     });
 
     it("should create root type with directive", () => {
-        const barType = type("bar").withStringField("poo", "test desc", ["compositeId"])
+        const barType = buildType("bar").withStringField("poo", "test desc", ["compositeId"])
             .withFloatField("puu");
-        const barIngester = ingester(barType).build();
+        const barIngester = buildIngester(barType).build();
         assert.deepEqual(barIngester, {
             root_type: "bar",
             types: [{
@@ -212,10 +212,10 @@ describe("ingesters", () => {
     });
 
     it("should create root type with argument", () => {
-        const fooType = type("foo").withBooleanField("fuu").withListScalarField("nums", "Int");
-        const barType = type("bar").withStringField("poo")
+        const fooType = buildType("foo").withBooleanField("fuu").withListScalarField("nums", "Int");
+        const barType = buildType("bar").withStringField("poo")
             .withFloatField("puu").withListObjectField("foos", fooType, "foos desc", ["fuu"]);
-        const barIngester = ingester("bar").withType(fooType).withType(barType).build();
+        const barIngester = buildIngester("bar").withType(fooType).withType(barType).build();
         assert.deepEqual(barIngester, {
             root_type: "bar",
             types: [{


### PR DESCRIPTION
This adds support for defining ingesters in GraphQL SDL format. By
convention those SDL files should have a graphql extension and
should be placed inside the graphql/ingester folder.

fixes #281