### PR TITLE
API simplification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 
 -   Remove dependency to config module. [#317](https://github.com/atomist/automation-client-ts/issues/317)
+-   `Project` no longer extends `AbstractScriptedFlushable`. This is no longer necessary given async/await
 
 ## [0.17.1](https://github.com/atomist/automation-client-ts/compare/0.17.0...0.17.1) - 2018-06-04
 

--- a/src/operations/edit/projectEditor.ts
+++ b/src/operations/edit/projectEditor.ts
@@ -1,9 +1,6 @@
 import { ActionResult } from "../../action/ActionResult";
 import { HandlerContext } from "../../HandlerContext";
-import {
-    isProject,
-    Project,
-} from "../../project/Project";
+import { isProject, Project } from "../../project/Project";
 
 /**
  * Modifies the given project, returning information about the modification.
@@ -57,8 +54,4 @@ export function failedEdit<P extends Project>(p: P, error: Error, edited: boolea
         error,
         edited,
     };
-}
-
-export function flushAndSucceed<P extends Project>(p: P): Promise<EditResult<P>> {
-    return p.flush().then(pf => successfulEdit(pf, undefined));
 }

--- a/src/project/Project.ts
+++ b/src/project/Project.ts
@@ -1,5 +1,4 @@
 import { Stream } from "stream";
-import { ScriptedFlushable } from "../internal/common/Flushable";
 import { RepoRef } from "../operations/common/RepoId";
 import { File } from "./File";
 
@@ -78,7 +77,7 @@ export interface ProjectSync extends ProjectCore {
 /**
  * Asynchronous Project operations, returning promises or node streams.
  */
-export interface ProjectAsync extends ProjectCore, ScriptedFlushable<Project> {
+export interface ProjectAsync extends ProjectCore {
 
     /**
      * Return a node stream of the files in the project meeting

--- a/src/project/util/parseUtils.ts
+++ b/src/project/util/parseUtils.ts
@@ -1,5 +1,6 @@
 import { Microgrammar } from "@atomist/microgrammar/Microgrammar";
 import { PatternMatch } from "@atomist/microgrammar/PatternMatch";
+import { ScriptedFlushable } from "../../internal/common/Flushable";
 import { logger } from "../../internal/util/logger";
 import { File } from "../File";
 import { ProjectAsync } from "../Project";
@@ -236,7 +237,7 @@ class UpdatingFileHits<M> implements FileWithMatches<M> {
                 });
             });
             // Track the file
-            this.project.recordAction(p => this.file.flush());
+            (this.project as any as ScriptedFlushable<any>).recordAction(p => this.file.flush());
             this.updatable = true;
         }
     }

--- a/src/tree/ast/FileHits.ts
+++ b/src/tree/ast/FileHits.ts
@@ -4,9 +4,10 @@ import {
     PathExpression,
 } from "@atomist/tree-path/path/pathExpression";
 import { TreeNode } from "@atomist/tree-path/TreeNode";
+import { ScriptedFlushable } from "../../internal/common/Flushable";
 import { logger } from "../../internal/util/logger";
 import { File } from "../../project/File";
-import { ProjectAsync } from "../../project/Project";
+import { Project, ProjectAsync } from "../../project/Project";
 import { LocatedTreeNode } from "../LocatedTreeNode";
 
 /**
@@ -75,7 +76,6 @@ export class FileHit {
                 public file: File,
                 public fileNode: TreeNode,
                 public readonly nodes: LocatedTreeNode[]) {
-
         const updates: Update[] = [];
 
         function doReplace(): Promise<File> {
@@ -105,7 +105,7 @@ export class FileHit {
 
         this.matches = nodes as MatchResult[];
         makeUpdatable(this.matches, updates);
-        project.recordAction(p => doReplace());
+        (project as any as ScriptedFlushable<Project>).recordAction(() => doReplace());
     }
 }
 

--- a/src/tree/ast/astUtils.ts
+++ b/src/tree/ast/astUtils.ts
@@ -185,7 +185,7 @@ export function zapAllMatches<P extends ProjectAsync = ProjectAsync>(p: P,
                     m.zap(opts);
                 });
             });
-            return p.flush();
+            return (p as any).flush();
         });
 }
 

--- a/test/project/local/NodeFsLocalProjectTest.ts
+++ b/test/project/local/NodeFsLocalProjectTest.ts
@@ -9,11 +9,12 @@ import { LocalProject } from "../../../src/project/local/LocalProject";
 import { File } from "../../../src/project/File";
 
 import * as fs from "fs";
-import { defer } from "../../../src/internal/common/Flushable";
+import { defer, ScriptedFlushable } from "../../../src/internal/common/Flushable";
 import { GitHubRepoRef } from "../../../src/operations/common/GitHubRepoRef";
 import { AllFiles, ExcludeNodeModules } from "../../../src/project/fileGlobs";
 import { NodeFsLocalProject } from "../../../src/project/local/NodeFsLocalProject";
 import { InMemoryProject } from "../../../src/project/mem/InMemoryProject";
+import { Project } from "../../../src/project/Project";
 import { toPromise } from "../../../src/project/util/projectUtils";
 import { tempProject } from "../utils";
 
@@ -241,7 +242,7 @@ describe("NodeFsLocalProject", () => {
     });
 
     it("adds file", done => {
-        const p = tempProject();
+        const p = tempProject() as any as Project & ScriptedFlushable<any>;
         defer(p, p.addFile("thing", "1"));
         assert(p.dirty);
         p.flush()
@@ -253,7 +254,7 @@ describe("NodeFsLocalProject", () => {
     });
 
     it("moves file that's there", done => {
-        const p = tempProject();
+        const p = tempProject() as any as Project & ScriptedFlushable<any>;
         defer(p, p.addFile("thing", "1"));
         assert(p.dirty);
         p.flush()
@@ -268,7 +269,7 @@ describe("NodeFsLocalProject", () => {
     });
 
     it("attempts to move file that's not there without error", done => {
-        const p = tempProject();
+        const p = tempProject() as any as Project & ScriptedFlushable<any>;
         defer(p, p.addFile("thing", "1"));
         assert(p.dirty);
         p.flush()
@@ -283,7 +284,7 @@ describe("NodeFsLocalProject", () => {
     });
 
     it("adds nested file", done => {
-        const p = tempProject();
+        const p = tempProject() as any as Project & ScriptedFlushable<any>;
         defer(p, p.addFile("config/thing", "1"));
         assert(p.dirty);
         p.flush()
@@ -295,7 +296,7 @@ describe("NodeFsLocalProject", () => {
     });
 
     it("adds deeply nested file", done => {
-        const p = tempProject();
+        const p = tempProject() as any as Project & ScriptedFlushable<any>;
         defer(p, p.addFile("config/and/more/thing", "1"));
         assert(p.dirty);
         p.flush()
@@ -307,7 +308,7 @@ describe("NodeFsLocalProject", () => {
     });
 
     it("deletes file", done => {
-        const p = tempProject();
+        const p = tempProject() as any as Project & ScriptedFlushable<any>;
         p.addFileSync("thing", "1");
         const f1 = p.findFileSync("thing");
         assert(f1.getContentSync() === "1");

--- a/test/project/util/parseUtilsTest.ts
+++ b/test/project/util/parseUtilsTest.ts
@@ -3,7 +3,7 @@ import "mocha";
 import { Microgrammar } from "@atomist/microgrammar/Microgrammar";
 import { Integer } from "@atomist/microgrammar/Primitives";
 import * as assert from "power-assert";
-import { defer } from "../../../src/internal/common/Flushable";
+import { defer, ScriptedFlushable } from "../../../src/internal/common/Flushable";
 import { AllFiles } from "../../../src/project/fileGlobs";
 import { InMemoryFile } from "../../../src/project/mem/InMemoryFile";
 import { InMemoryProject } from "../../../src/project/mem/InMemoryProject";
@@ -125,7 +125,7 @@ describe("parseUtils", () => {
         updateMatchesFromFiles(tempProject(), done);
     });
 
-    function updateMatchesFromFiles(p: Project, done) {
+    function updateMatchesFromFiles(p: Project & ScriptedFlushable<Project>, done) {
         const oldPackage = "com.foo.bar";
         const initialContent = `package ${oldPackage};\npublic class Thing {}`;
         const f = new InMemoryFile("src/main/java/com/foo/bar/Thing.java", initialContent);

--- a/test/project/utils.ts
+++ b/test/project/utils.ts
@@ -1,12 +1,17 @@
 import { LocalProject } from "../../src/project/local/LocalProject";
 
 import * as tmp from "tmp-promise";
+import { ScriptedFlushable } from "../../src/internal/common/Flushable";
 import { RepoRef } from "../../src/operations/common/RepoId";
 import { NodeFsLocalProject } from "../../src/project/local/NodeFsLocalProject";
 
 tmp.setGracefulCleanup();
 
-export function tempProject(id: RepoRef = { owner: "dummyOwner", repo: "dummyRepo" }): LocalProject {
+export function tempProject(id: RepoRef = {
+    owner: "dummyOwner",
+    repo: "dummyRepo",
+}): LocalProject & ScriptedFlushable<LocalProject> {
     const dir = tmp.dirSync({ unsafeCleanup: true });
-    return new NodeFsLocalProject(id, dir.name, () => Promise.resolve()); // could delete the dir in release function
+    return new NodeFsLocalProject(id, dir.name,
+        () => Promise.resolve()) as any as LocalProject & ScriptedFlushable<LocalProject>; // could delete the dir in release function
 }


### PR DESCRIPTION
`Project` interface no longer extends `ScriptedFlushable`, as this model is no longer necessary with async/await. Implementation does not change, but these details are hidden.