### PR TITLE
HTTP client and factory abstraction

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -43,6 +43,8 @@ import {
 import { AutomationEventListener } from "./server/AutomationEventListener";
 import { AutomationMetadataProcessor } from "./spi/env/MetadataProcessor";
 import { SecretResolver } from "./spi/env/SecretResolver";
+import { DefaultHttpClientFactory } from "./spi/http/axiosHttpClient";
+import { HttpClientFactory } from "./spi/http/httpClient";
 import { Maker } from "./util/constructionUtils";
 
 /**
@@ -129,7 +131,12 @@ export interface AutomationOptions extends AnyOptions {
      */
     token?: string;
     /** HTTP configuration, useful for health checks */
-    http?: { enabled?: boolean } & Partial<ExpressServerOptions>;
+    http?: {
+        enabled?: boolean
+        client?: {
+            factory?: HttpClientFactory,
+        },
+    } & Partial<ExpressServerOptions>;
     /** websocket configuration */
     ws?: {
         enabled?: boolean;
@@ -882,6 +889,9 @@ export const LocalDefaultConfiguration: Configuration = {
             },
         },
         customizers: [],
+        client: {
+            factory: DefaultHttpClientFactory,
+        },
     },
     ws: {
         enabled: true,

--- a/src/spi/http/axiosHttpClient.ts
+++ b/src/spi/http/axiosHttpClient.ts
@@ -1,0 +1,62 @@
+import axios from "axios";
+import { configureProxy } from "../../internal/util/http";
+import { doWithRetry } from "../../util/retry";
+import {
+    DefaultHttpClientOptions,
+    HttpClient,
+    HttpClientFactory,
+    HttpClientOptions,
+    HttpResponse,
+} from "./httpClient";
+
+/**
+ * Axios based HttpClient implementation.
+ */
+export class AxiosHttpClient implements HttpClient {
+
+    public exchange<T>(url: string,
+                       options: HttpClientOptions = {}): Promise<HttpResponse<T>> {
+
+        const optionsToUse: HttpClientOptions = {
+            ...DefaultHttpClientOptions,
+            ...options,
+        };
+
+        const request = () => {
+            return axios.request(configureProxy({
+                    url,
+                    headers: optionsToUse.headers,
+                    method: optionsToUse.method.toString().toUpperCase(),
+                    data: optionsToUse.body,
+                    ...optionsToUse.options,
+                }))
+                .then(result => {
+                    return {
+                        status: result.status,
+                        headers: result.headers,
+                        body: result.data,
+                    };
+                });
+        };
+
+        return doWithRetry<HttpResponse<T>>(request, `Requesting '${url}'`, optionsToUse.retry);
+    }
+}
+
+/**
+ * HttpClientFactory that creates HttpClient instances backed by Axios.
+ */
+export class AxiosHttpClientFactory implements HttpClientFactory {
+
+    public create(url?: string): HttpClient {
+        return new AxiosHttpClient();
+    }
+}
+
+/**
+ * Default HttpClientFactory which gets registered in the automation-client if not a
+ * different HttpClientFactory implementation is configured.
+ * @see Configuration.http.client.factory
+ * @type {HttpClientFactory}
+ */
+export const DefaultHttpClientFactory = new AxiosHttpClientFactory();

--- a/src/spi/http/curlHttpClient.ts
+++ b/src/spi/http/curlHttpClient.ts
@@ -1,0 +1,108 @@
+import * as _ from "lodash";
+import * as os from "os";
+import { logger } from "../..";
+import { doWithRetry } from "../../util/retry";
+import {
+    spawnAndWatch,
+    SuccessIsReturn0ErrorFinder,
+    WritableLog,
+} from "../../util/spawned";
+import {
+    DefaultHttpClientOptions,
+    HttpClient,
+    HttpClientFactory,
+    HttpClientOptions,
+    HttpResponse,
+} from "./httpClient";
+
+/**
+ * Curl based HttpClient implementation.
+ */
+export class CurlHttpClient implements HttpClient {
+
+    public exchange<T>(url: string,
+                       options: HttpClientOptions = {}): Promise<HttpResponse<T>> {
+
+        const optionsToUse: HttpClientOptions = {
+            ...DefaultHttpClientOptions,
+            ...options,
+        };
+
+        // Prepare headers
+        const headers = [];
+        _.forEach(optionsToUse.headers, (v, k) => {
+            headers.push(`${k}: ${v}`);
+        });
+
+        // Prepare the provided raw curl options
+        const rawOptions = [];
+        _.forEach(optionsToUse.options, (v, k) => {
+            if (k.length === 1) {
+                rawOptions.push([ `-${k}`, v ]);
+            } else {
+                rawOptions.push([ `--${k}`, v ]);
+            }
+        });
+
+        const request = () => {
+
+            let log = "";
+            const passthroughLog: WritableLog = {
+                write(str: string) {
+                    logger.debug(str);
+                    log += str;
+                },
+            };
+
+            return spawnAndWatch({
+                    command: "curl",
+                    args: [
+                        "-X", optionsToUse.method,
+                        url,
+                        "-s",
+                        "--write-out",
+                        "HTTPSTATUS:%{http_code}",
+                        ..._.flatten(headers.map(h => ([ "-H", h ]))),
+                        ..._.flatten(rawOptions),
+                        ...(options.body ? [ "-d", JSON.stringify(options.body) ] : []),
+                    ],
+                },
+                {},
+                passthroughLog,
+                {
+                    logCommand: false,
+                    errorFinder: SuccessIsReturn0ErrorFinder,
+                })
+                .then(result => {
+                    const parts = log.split("HTTPSTATUS:");
+                    let body = parts[ 0 ];
+
+                    try {
+                        body = JSON.parse(body);
+                    } catch (err) {
+                        // ignore
+                    }
+
+                    return {
+                        status: +parts[ 1 ],
+                        body,
+                    } as any as HttpResponse<T>;
+                });
+        };
+
+        return doWithRetry<HttpResponse<T>>(request, `Requesting '${url}'`, optionsToUse.retry);
+    }
+}
+
+/**
+ * HttpClientFactory that creates HttpClient instances backed by curl.
+ */
+export class CurlHttpClientFactory implements HttpClientFactory {
+
+    public create(url?: string): HttpClient {
+        if (os.platform() === "win32") {
+            throw new Error("CurlHttpClient is not available on Windows.");
+        }
+        return new CurlHttpClient();
+    }
+}

--- a/src/spi/http/httpClient.ts
+++ b/src/spi/http/httpClient.ts
@@ -1,0 +1,88 @@
+import { WrapOptions } from "retry";
+import { DefaultRetryOptions } from "../../util/retry";
+import { AxiosHttpClientFactory } from "./axiosHttpClient";
+
+/**
+ * Available HTTP request methods to use with HttpClient.
+ */
+export enum HttpMethod {
+    Get = "GET",
+    Post = "POST",
+    Put = "PUT",
+    Delete = "DELETE",
+    Options = "OPTIONS",
+    Patch = "PATCH",
+}
+
+/**
+ * HTTP options to pass into HttpClient.exchange.
+ */
+export interface HttpClientOptions {
+    /** Optional HTTP request method; defaults to HtppMethod.Get */
+    method?: HttpMethod;
+
+    /** Optional HTTP headers to be included in the request */
+    headers?: { [name: string]: string };
+
+    /** Optional payload body to be sent */
+    body?: any;
+
+    /** Optional retry options */
+    retry?: WrapOptions;
+
+    /** Raw options to be passed to the underlying implementation; Please use with care */
+    options?: any;
+}
+
+/**
+ * HTTP response from HttpClient.exchange.
+ */
+export interface HttpResponse<T> {
+    /** HTTP status code */
+    status: number;
+
+    /** Optional HTTP headers to server returned */
+    headers?: { [name: string]: string };
+
+    /** Optional response body of type T */
+    body?: T;
+}
+
+/**
+ * HTTP request abstraction to be implemented by different frameworks and command line
+ * tools.
+ */
+export interface HttpClient {
+
+    /**
+     * Exchange the given HTTP request with the server at url.
+     * @param {string} url
+     * @param {HttpClientOptions} options
+     * @returns {Promise<HttpResponse<T>>}
+     */
+    exchange<T>(url: string,
+                options?: HttpClientOptions): Promise<HttpResponse<T>>;
+}
+
+/**
+ * Factory to construct HttpClient instances.
+ */
+export interface HttpClientFactory {
+
+    /**
+     * Create a HttpClient for the given url.
+     * @param {string} url
+     * @returns {HttpClient}
+     */
+    create(url?: string): HttpClient;
+}
+
+/**
+ * Default HTTP client options each implementation to should use.
+ * @type {{method: HttpMethod; headers: {}; retry: WrapOptions}}
+ */
+export const DefaultHttpClientOptions: HttpClientOptions = {
+    method: HttpMethod.Get,
+    headers: {},
+    retry: DefaultRetryOptions,
+};

--- a/src/util/retry.ts
+++ b/src/util/retry.ts
@@ -22,7 +22,8 @@ export const DefaultRetryOptions: WrapOptions = {
  * @param {Object} opts
  * @return {Promise<R>}
  */
-export function doWithRetry<R>(what: () => Promise<R>, description: string,
+export function doWithRetry<R>(what: () => Promise<R>,
+                               description: string,
                                opts: WrapOptions = {}): Promise<R> {
     const retryOptions: WrapOptions = {
         ...DefaultRetryOptions,

--- a/test/configurationTest.ts
+++ b/test/configurationTest.ts
@@ -29,6 +29,7 @@ import {
     TestingDefaultConfiguration,
     UserConfig,
 } from "../src/configuration";
+import { DefaultHttpClientFactory } from "../src/spi/http/axiosHttpClient";
 
 describe("configuration", () => {
 
@@ -69,6 +70,9 @@ describe("configuration", () => {
                 },
             },
             customizers: [],
+            client: {
+                factory: DefaultHttpClientFactory,
+            },
         },
         ws: {
             enabled: true,

--- a/test/spi/http/axiosHttpClientTest.ts
+++ b/test/spi/http/axiosHttpClientTest.ts
@@ -1,0 +1,97 @@
+/*
+ * Copyright © 2018 Atomist, Inc.
+ *
+ * See LICENSE file.
+ */
+
+import * as http from "http";
+import "mocha";
+import * as os from "os";
+import * as assert from "power-assert";
+import { AxiosHttpClientFactory } from "../../../src/spi/http/axiosHttpClient";
+import { HttpMethod } from "../../../src/spi/http/httpClient";
+
+const hostname = os.hostname();
+
+describe("axiosHttpClient", () => {
+
+    let server;
+
+    afterEach(() => {
+        server.close();
+    });
+
+    it("should exchange simple get",  done => {
+        server = http.createServer((req, res) => {
+            assert.strictEqual(req.method, "GET");
+            assert.strictEqual(req.url, "/foo/bar.html");
+            res.writeHead(200, {"Content-Type": "text/plain"});
+            res.end("foo and bar");
+        }).listen(9999, hostname);
+
+        setTimeout(async () => {
+            const hcf = new AxiosHttpClientFactory();
+            const hc = hcf.create(`http://${hostname}:9999/foo/bar.html`);
+
+            const r = await hc.exchange(`http://${hostname}:9999/foo/bar.html`);
+            assert.strictEqual(r.status, 200);
+            assert.strictEqual(r.body, "foo and bar");
+            done();
+        }, 3000);
+
+    }).timeout(10000);
+
+    it("should exchange simple put",  done => {
+        server = http.createServer((req, res) => {
+            assert.strictEqual(req.method, "PUT");
+            assert.strictEqual(req.url, "/foo");
+            assert.strictEqual(req.headers["content-type"], "application/json");
+
+            res.writeHead(201);
+            res.end();
+        }).listen(9999, hostname);
+
+        setTimeout(async () => {
+            const hcf = new AxiosHttpClientFactory();
+            const hc = hcf.create(`http://${hostname}:9999/foo`);
+
+            const r = await hc.exchange(`http://${hostname}:9999/foo`, {
+                method: HttpMethod.Put,
+                headers: {
+                    "Content-Type": "application/json",
+                },
+                body: { blupp: "bla" },
+            });
+            assert.strictEqual(r.status, 201);
+            done();
+        }, 3000);
+    }).timeout(10000);
+
+    it("should exchange simple post with response", done => {
+        server = http.createServer((req, res) => {
+            assert.strictEqual(req.method, "POST");
+            assert.strictEqual(req.url, "/foo");
+            assert.strictEqual(req.headers["content-type"], "application/json");
+
+            res.writeHead(201);
+            res.end(JSON.stringify({ bla: "blupp" }));
+        }).listen(9999, hostname);
+
+        setTimeout(async () => {
+            const hcf = new AxiosHttpClientFactory();
+            const hc = hcf.create(`http://${hostname}:9999/foo`);
+
+            const r = await hc.exchange(`http://${hostname}:9999/foo`, {
+                method: HttpMethod.Post,
+                headers: {
+                    "Content-Type": "application/json",
+                },
+                body: { bla: "blupp" },
+            });
+            assert.strictEqual(r.status, 201);
+            assert.deepEqual(r.body, { bla: "blupp" });
+            done();
+        }, 3000);
+    }).timeout(10000);
+
+});

--- a/test/spi/http/curlHttpClientTest.ts
+++ b/test/spi/http/curlHttpClientTest.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright © 2018 Atomist, Inc.
+ *
+ * See LICENSE file.
+ */
+
+import * as http from "http";
+import "mocha";
+import * as os from "os";
+import * as assert from "power-assert";
+import { CurlHttpClientFactory } from "../../../src/spi/http/curlHttpClient";
+import { HttpMethod } from "../../../src/spi/http/httpClient";
+
+const hostname = os.hostname();
+
+describe("curlHttpClient", () => {
+
+    let server;
+
+    afterEach(() => {
+        server.close();
+    });
+
+    it("should exchange simple get", async () => {
+        server = http.createServer((req, res) => {
+            assert.strictEqual(req.method, "GET");
+            assert.strictEqual(req.url, "/foo/bar.html");
+            res.writeHead(200, {"Content-Type": "text/plain"});
+            res.end("foo and bar");
+        }).listen(9999, hostname);
+
+        const hcf = new CurlHttpClientFactory();
+        const hc = hcf.create(`http://${hostname}:9999/foo`);
+
+        const r = await hc.exchange(`http://${hostname}:9999/foo/bar.html`);
+        assert.strictEqual(r.status, 200);
+        assert.strictEqual(r.body, "foo and bar");
+    }).timeout(10000);
+
+    it("should exchange simple put", async () => {
+        server = http.createServer((req, res) => {
+            assert.strictEqual(req.method, "PUT");
+            assert.strictEqual(req.url, "/foo");
+            assert.strictEqual(req.headers["content-type"], "application/json");
+
+            res.writeHead(201);
+            res.end();
+        }).listen(9999, hostname);
+
+        const hcf = new CurlHttpClientFactory();
+        const hc = hcf.create(`http://${hostname}:9999/foo`);
+
+        const r = await hc.exchange(`http://${hostname}:9999/foo`, {
+            method: HttpMethod.Put,
+            headers: {
+                "Content-Type": "application/json",
+            },
+            body: { blupp: "bla" },
+        });
+        assert.strictEqual(r.status, 201);
+    }).timeout(10000);
+
+    it("should exchange simple post with response", async () => {
+        server = http.createServer((req, res) => {
+            assert.strictEqual(req.method, "POST");
+            assert.strictEqual(req.url, "/foo");
+            assert.strictEqual(req.headers["content-type"], "application/json");
+
+            res.writeHead(201);
+            res.end(JSON.stringify({ bla: "blupp" }));
+        }).listen(9999, hostname);
+
+        const hcf = new CurlHttpClientFactory();
+        const hc = hcf.create(`http://${hostname}:9999/foo`);
+
+        const r = await hc.exchange(`http://${hostname}:9999/foo`, {
+            method: HttpMethod.Post,
+            headers: {
+                "Content-Type": "application/json",
+            },
+            body: { bla: "blupp" },
+        });
+        assert.strictEqual(r.status, 201);
+        assert.deepEqual(r.body, { bla: "blupp" });
+    }).timeout(10000);
+
+});


### PR DESCRIPTION
This provides new `HttpClient` and `HttpClientFactory` interfaces. The latter can get registered on `configuration.http.client.factory` and overwrite the default of `AxiosHttpClientFactory`. 

I provided a `curl`-based implementation.