### PR TITLE
Work around 'Type ... is not assignable to type Configuration'

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -224,7 +224,7 @@
     },
     "@types/graphql": {
       "version": "0.12.7",
-      "resolved": "https://registry.npmjs.org/@types/graphql/-/graphql-0.12.7.tgz",
+      "resolved": "http://registry.npmjs.org/@types/graphql/-/graphql-0.12.7.tgz",
       "integrity": "sha512-xuf/9ShwOOlxoV+J5ts4vAoPbL3nmcFU3z/Ad6jrsiB99hB/Wrs2fl3qJga5XJ1euAasMN/FsNPdHMV6+OV5vw=="
     },
     "@types/handlebars": {
@@ -747,7 +747,7 @@
       "dependencies": {
         "@types/graphql": {
           "version": "0.12.6",
-          "resolved": "https://registry.npmjs.org/@types/graphql/-/graphql-0.12.6.tgz",
+          "resolved": "http://registry.npmjs.org/@types/graphql/-/graphql-0.12.6.tgz",
           "integrity": "sha512-wXAVyLfkG1UMkKOdMijVWFky39+OD/41KftzqfX1Oejd0Gm6dOIKjCihSVECg6X7PHjftxXmfOKA/d1H79ZfvQ=="
         }
       }
@@ -2036,7 +2036,7 @@
     },
     "event-stream": {
       "version": "3.3.4",
-      "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
       "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
       "dev": true,
       "requires": {

--- a/src/ingesters.ts
+++ b/src/ingesters.ts
@@ -95,10 +95,18 @@ export class IngesterBuilder {
 
 /**
  * Builder to construct TypeBuilder instances fluently
+ * @Deprecated use the SDL (GraphQL Schema definition language) ingester definition.
  */
 export class TypeBuilder {
 
-    private fields: FieldType[] = [];
+    /**
+     * do not use! This is public only to prevent compiler errors when the location of automation-client is not
+     * identical for dependencies within an SDM.
+     *
+     * @Deprecated
+     * @type {any[]}
+     */
+    public readonly fields: FieldType[] = [];
 
     constructor(public name: string, public description?: string) { }
 


### PR DESCRIPTION
When Configuration contains a class with private/protected fields, at any level,
then a Configuration that resolves to one installation of automation-client
is _never_ the same type that resolves to a Configuration that resolves o
another installation, even if they're the same version, if they're in different
spots on the filesystem. TypeScript protects us. :-/
So don't do it. It's better to never require a class, but only an interface.
Right now I want to see if this will get us around the problem.