### PR TITLE
Work around Type ... is not assignable to type Configuration'

### DIFF
--- a/src/ingesters.ts
+++ b/src/ingesters.ts
@@ -62,9 +62,24 @@ export interface FieldType {
  */
 export class IngesterBuilder {
 
-    private types: ObjectType[] = [];
-    private enums: EnumType[] = [];
-    private name: string;
+    /**
+     * @Deprecated do not use
+     * Public to prevent type errors. This whole class will be removed in the future
+     * @type {any[]}
+     */
+    public types: ObjectType[] = [];
+    /**
+     * @Deprecated do not use
+     * Public to prevent type errors. This whole class will be removed in the future
+     * @type {any[]}
+     */
+    public enums: EnumType[] = [];
+    /**
+     * @Deprecated do not use
+     * Public to prevent type errors. This whole class will be removed in the future
+     * @type {any[]}
+     */
+    public name: string;
 
     constructor(public rootType: string | TypeBuilder) {
         if (isString(rootType)) {


### PR DESCRIPTION
here's another one.
I don't know why it didn't show up in my testing earlier, but it's biting me now.
If this weren't deprecated I'd hide the class behind an interface instead, but that's more work