### PR TITLE
Do not send circular JSON back from event handlers

### DIFF
--- a/src/internal/transport/AbstractRequestProcessor.ts
+++ b/src/internal/transport/AbstractRequestProcessor.ts
@@ -244,12 +244,20 @@ export abstract class AbstractRequestProcessor implements RequestProcessor {
                           callback: (results: Promise<HandlerResult[]>) => void) {
 
         const finalize = (results: HandlerResult[]) => {
-            this.sendEventStatus(results.some(r => r.code !== 0) ? false : true, ef, event, ctx)
+            let noncircularResults = results;
+            try {
+                JSON.stringify(noncircularResults)
+            } catch (err) {
+                logger.error("Circular JSON returned from event handler: %s", stringify(results));
+                noncircularResults = results.map(r => ({ code: r.code, message: stringify(r.message) }))
+            }
+
+            this.sendEventStatus(!results.some(r => r.code !== 0), ef, event, ctx)
                 .catch(err =>
                     logger.warn("Unable to send status for event subscription'%s': %s",
                         event.extensions.operationName, err.message))
                 .then(() => {
-                    callback(Promise.resolve(results));
+                    callback(Promise.resolve(noncircularResults));
                     logger.info(`Finished invocation of event subscription '%s': %s`,
                         event.extensions.operationName, stringify(results, possibleAxiosObjectReplacer));
                     this.clearNamespace();

--- a/src/internal/transport/AbstractRequestProcessor.ts
+++ b/src/internal/transport/AbstractRequestProcessor.ts
@@ -246,7 +246,7 @@ export abstract class AbstractRequestProcessor implements RequestProcessor {
         const finalize = (results: HandlerResult[]) => {
             let noncircularResults = results;
             try {
-                JSON.stringify(noncircularResults)
+                JSON.stringify(noncircularResults);
             } catch (err) {
                 logger.error("Circular object returned from event handler: %s", stringify(results));
                 noncircularResults = results.map(r => ({ code: r.code, message: stringify(r.message) }));

--- a/src/internal/transport/AbstractRequestProcessor.ts
+++ b/src/internal/transport/AbstractRequestProcessor.ts
@@ -248,18 +248,19 @@ export abstract class AbstractRequestProcessor implements RequestProcessor {
             try {
                 JSON.stringify(noncircularResults)
             } catch (err) {
-                logger.error("Circular JSON returned from event handler: %s", stringify(results));
-                noncircularResults = results.map(r => ({ code: r.code, message: stringify(r.message) }))
+                logger.error("Circular object returned from event handler: %s", stringify(results));
+                noncircularResults = results.map(r => ({ code: r.code, message: stringify(r.message) }));
+                logger.error("Substituting for circular object: %j", noncircularResults);
             }
 
-            this.sendEventStatus(!results.some(r => r.code !== 0), ef, event, ctx)
+            this.sendEventStatus(!noncircularResults.some(r => r.code !== 0), ef, event, ctx)
                 .catch(err =>
                     logger.warn("Unable to send status for event subscription'%s': %s",
                         event.extensions.operationName, err.message))
                 .then(() => {
                     callback(Promise.resolve(noncircularResults));
                     logger.info(`Finished invocation of event subscription '%s': %s`,
-                        event.extensions.operationName, stringify(results, possibleAxiosObjectReplacer));
+                        event.extensions.operationName, stringify(noncircularResults, possibleAxiosObjectReplacer));
                     this.clearNamespace();
                 });
         };


### PR DESCRIPTION
This was failing with TypeError in the response to /events.
It resulted in a socket hang up.

You may have a better way to defend against this.