### PR TITLE
If no event handlers are found, return 404 not 500

### DIFF
--- a/src/internal/transport/express/ExpressServer.ts
+++ b/src/internal/transport/express/ExpressServer.ts
@@ -14,6 +14,7 @@ import {
 import * as globals from "../../../globals";
 import { automationClientInstance } from "../../../globals";
 import { AutomationContextAware } from "../../../HandlerContext";
+import { noEventHandlersWereFound } from "../../../server/AbstractAutomationServer";
 import { AutomationEventListener } from "../../../server/AutomationEventListener";
 import { AutomationServer } from "../../../server/AutomationServer";
 import { GraphClient } from "../../../spi/graph/GraphClient";
@@ -130,7 +131,8 @@ export class ExpressServer {
             `${ApiBase}/event`, cors,
             (req, res, result) => {
                 const results = Array.isArray(result) ? result : [result];
-                const code = results.some(r => r.code !== 0) ? 500 : 200;
+                const code = noEventHandlersWereFound(result) ? 404 :
+                    results.some(r => r.code !== 0) ? 500 : 200;
                 res.status(code).json(result);
             });
 
@@ -151,7 +153,7 @@ export class ExpressServer {
             exp.listen(this.configuration.http.port, () => {
                 logger.debug(
                     `Atomist automation client api running at 'http://${
-                        this.configuration.http.host}:${this.configuration.http.port}'`);
+                    this.configuration.http.host}:${this.configuration.http.port}'`);
             }).on("error", err => {
                 logger.warn("Starting automation client api failed: %s", err.message);
                 if (operation.retry(err)) {
@@ -271,7 +273,7 @@ export class ExpressServer {
                             console.log(err);
                             return done(null, false);
                         });
-                    },
+                },
             ));
         }
     }

--- a/src/server/AbstractAutomationServer.ts
+++ b/src/server/AbstractAutomationServer.ts
@@ -64,9 +64,9 @@ export abstract class AbstractAutomationServer implements AutomationServer {
     }
 
     protected abstract invokeCommandHandler(payload: CommandInvocation, h: CommandHandlerMetadata,
-        ctx: HandlerContext): Promise<HandlerResult>;
+                                            ctx: HandlerContext): Promise<HandlerResult>;
 
     protected abstract invokeEventHandler(payload: EventFired<any>, h: EventHandlerMetadata,
-        ctx: HandlerContext): Promise<HandlerResult>;
+                                          ctx: HandlerContext): Promise<HandlerResult>;
 
 }

--- a/src/server/AbstractAutomationServer.ts
+++ b/src/server/AbstractAutomationServer.ts
@@ -12,6 +12,11 @@ import {
 } from "../metadata/automationMetadata";
 import { AutomationServer } from "./AutomationServer";
 
+export const NoEventHandlersError = "NO_EVENT_HANDLERS";
+export function noEventHandlersWereFound(result: HandlerResult) {
+    return result.code !== 0 && result.message.startsWith(NoEventHandlersError);
+}
+
 /**
  * Support for implementing an automation server.
  */
@@ -27,7 +32,7 @@ export abstract class AbstractAutomationServer implements AutomationServer {
     public onEvent(payload: EventFired<any>, ctx: HandlerContext): Promise<HandlerResult[]> {
         const h = this.automations.events.filter(eh => eh.subscriptionName === payload.extensions.operationName);
         if (!h || h.length === 0) {
-            throw new Error(`No event handler with name '${payload.extensions.operationName}'` +
+            throw new Error(`${NoEventHandlersError}: No event handler with name '${payload.extensions.operationName}'` +
                 `: Known event handlers are '${this.automations.events.map(e => e.name)}'`);
         } else {
             return Promise.all(h.map(eh => this.invokeEventHandler(payload, eh, ctx)));
@@ -59,9 +64,9 @@ export abstract class AbstractAutomationServer implements AutomationServer {
     }
 
     protected abstract invokeCommandHandler(payload: CommandInvocation, h: CommandHandlerMetadata,
-                                            ctx: HandlerContext): Promise<HandlerResult>;
+        ctx: HandlerContext): Promise<HandlerResult>;
 
     protected abstract invokeEventHandler(payload: EventFired<any>, h: EventHandlerMetadata,
-                                          ctx: HandlerContext): Promise<HandlerResult>;
+        ctx: HandlerContext): Promise<HandlerResult>;
 
 }


### PR DESCRIPTION
Then I am trying to make sdm-local treat 404 as OK from this endpoint; it's OK if there are no handlers