### PR TITLE
Remove dimensions on metrics

### DIFF
--- a/src/util/statsd.ts
+++ b/src/util/statsd.ts
@@ -56,7 +56,6 @@ export class StatsdAutomationEventListener extends AutomationEventListenerSuppor
             const tags = [
                 `atomist_operation:${context.operation}`,
                 `atomist_operation_type:command`,
-                ...this.teamDetail(ctx),
             ];
 
             ctx.graphClient = {
@@ -178,9 +177,7 @@ export class StatsdAutomationEventListener extends AutomationEventListenerSuppor
 
     public commandSuccessful(payload: CommandInvocation, ctx: HandlerContext, result: HandlerResult): Promise<any> {
         const tags = [
-            `atomist_operation:${payload.name}`,
             `atomist_operation_type:command`,
-            ...this.teamDetail(ctx),
         ];
         this.increment("counter.operation.success", tags);
         this.timing("timer.operation", ctx, tags);
@@ -201,9 +198,7 @@ export class StatsdAutomationEventListener extends AutomationEventListenerSuppor
 
     public eventSuccessful(payload: EventFired<any>, ctx: HandlerContext, result: HandlerResult[]): Promise<any> {
         const tags = [
-            `atomist_operation:${payload.extensions.operationName}`,
             `atomist_operation_type:event`,
-            ...this.teamDetail(ctx),
         ];
         this.increment("counter.operation.success", tags);
         this.timing("timer.operation", ctx, tags);


### PR DESCRIPTION
Hi @cdupuis -- I've just been trying to sort out our biggest metrics today.

Some of these ones reported more than 15,000 in the last hour due to the combination of all the dimensions present.

This is my suggestion for what would be great to cut down the metric use but I'm not sure how much these are used and how important they are to you.

Removing team based dimensions is usually the most important thing - that and not have multiple changeable dimensions (tags) on one metric.

I've left all the dimensions on the failure metrics as they don't occur a lot and are probably the most important.

Let me know what you think. I've been through this process for the backend services now.