### PR TITLE
Export all of MessageClient

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -126,8 +126,4 @@ export {
     QueryOptions,
 } from "./spi/graph/GraphClient";
 
-export {
-    Destination,
-    MessageOptions,
-    SlackDestination,
-} from "./spi/message/MessageClient";
+export * from "./spi/message/MessageClient";


### PR DESCRIPTION
Export from the index all exports from MessageClient.  Add TypeDoc to
help make inputs and returns more clear.  Rename "rug" functions to
"chat".