### PR TITLE
Throw a particular error if credentials do not exist

### DIFF
--- a/src/operations/common/AbstractRemoteRepoRef.ts
+++ b/src/operations/common/AbstractRemoteRepoRef.ts
@@ -80,6 +80,9 @@ export abstract class AbstractRemoteRepoRef implements RemoteRepoRef {
     }
 
     public cloneUrl(creds: ProjectOperationCredentials) {
+        if (!creds) {
+            throw new Error("Credentials are undefined");
+        }
         if (isBasicAuthCredentials(creds)) {
             return `${this.scheme}${encodeURIComponent(creds.username)}:${encodeURIComponent(creds.password)}@` +
                 `${this.remoteBase}/${this.pathComponent}.git`;


### PR DESCRIPTION
It's better than 'Cannot read property 'username' of undefined' which is what I was getting
and I think this is a better place to throw than isBasicAuthCredentials