### PR TITLE
Match comment to code

### DIFF
--- a/src/spi/clone/DirectoryManager.ts
+++ b/src/spi/clone/DirectoryManager.ts
@@ -17,7 +17,7 @@ export interface CloneOptions {
 
     /**
      * Set this to the number of commits that should be cloned into the transient
-     * place. This only applies to master branches with alwaysDeep set to false.
+     * place. This only applies when alwaysDeep is set to false.
      */
     depth?: number;
 }


### PR DESCRIPTION
It's checking the branch and using --branch to get whichever one, in clone