### PR TITLE
Upgrade tree-path library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,17 +19,18 @@
       }
     },
     "@atomist/tree-path": {
-      "version": "0.1.9",
-      "resolved": "http://registry.npmjs.org/@atomist/tree-path/-/tree-path-0.1.9.tgz",
-      "integrity": "sha512-lDTCBAd8lJeWswipBHFDvVNj5AMcYgHEX7jd9yZJbuRii8cLXJVxOPTTyczmEtG367YzMSm61AKBzY7ucSE3Ow==",
+      "version": "https://r.atomist.com/1089073149",
+      "integrity": "sha512-oOozsu5SeQC84bMfvSMDybCm43wehAA9nGvfbyxgnlYiCpZfAIWOMABZhrOXkA4hBS4nAgdYRUF8N/6w/F5vMA==",
       "requires": {
-        "@atomist/microgrammar": "^0.7.0"
+        "@atomist/microgrammar": "^1.0.0-M.1",
+        "@types/lodash": "^4.14.116",
+        "lodash": "^4.17.10"
       },
       "dependencies": {
         "@atomist/microgrammar": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/@atomist/microgrammar/-/microgrammar-0.7.0.tgz",
-          "integrity": "sha512-RtdJA8QodmVchEdWDvLOaeYrASU8Y12/pFHqDOXkGyjgmP+svZaHL2YEdGDjy++ArVL3lpCNXG7ZPYPjVKTugQ=="
+          "version": "1.0.0-M.1",
+          "resolved": "https://registry.npmjs.org/@atomist/microgrammar/-/microgrammar-1.0.0-M.1.tgz",
+          "integrity": "sha512-gf8XYBz7RPVoUdJj4CGvCi+0SWgrd2HiaBNMRAYbqBR/1BuzBwR/EjCeLljdiRkRyRExfWb3zEiDRsBCbtToAw=="
         }
       }
     },
@@ -583,7 +584,7 @@
       "dependencies": {
         "@types/graphql": {
           "version": "0.12.6",
-          "resolved": "https://registry.npmjs.org/@types/graphql/-/graphql-0.12.6.tgz",
+          "resolved": "http://registry.npmjs.org/@types/graphql/-/graphql-0.12.6.tgz",
           "integrity": "sha512-wXAVyLfkG1UMkKOdMijVWFky39+OD/41KftzqfX1Oejd0Gm6dOIKjCihSVECg6X7PHjftxXmfOKA/d1H79ZfvQ=="
         }
       }
@@ -689,7 +690,7 @@
       "dependencies": {
         "chalk": {
           "version": "0.3.0",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-0.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.3.0.tgz",
           "integrity": "sha1-HJhDdzfxGZ68wdTEj9Qbn5yOjyM=",
           "requires": {
             "ansi-styles": "~0.2.0",
@@ -804,7 +805,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -1859,7 +1860,7 @@
     },
     "event-stream": {
       "version": "3.3.4",
-      "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
       "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
       "dev": true,
       "requires": {
@@ -2342,7 +2343,7 @@
     },
     "graphql-code-generator": {
       "version": "0.8.21",
-      "resolved": "http://registry.npmjs.org/graphql-code-generator/-/graphql-code-generator-0.8.21.tgz",
+      "resolved": "https://registry.npmjs.org/graphql-code-generator/-/graphql-code-generator-0.8.21.tgz",
       "integrity": "sha1-Nky5foI4MrI0jwv+3rlM5U/mRrE=",
       "requires": {
         "@types/prettier": "1.10.0",
@@ -2374,7 +2375,7 @@
     },
     "graphql-codegen-compiler": {
       "version": "0.8.21",
-      "resolved": "http://registry.npmjs.org/graphql-codegen-compiler/-/graphql-codegen-compiler-0.8.21.tgz",
+      "resolved": "https://registry.npmjs.org/graphql-codegen-compiler/-/graphql-codegen-compiler-0.8.21.tgz",
       "integrity": "sha1-VscWq7dufDBcX1C0aYy2xqL8g48=",
       "requires": {
         "@types/handlebars": "4.0.36",
@@ -2388,7 +2389,7 @@
     },
     "graphql-codegen-core": {
       "version": "0.8.21",
-      "resolved": "http://registry.npmjs.org/graphql-codegen-core/-/graphql-codegen-core-0.8.21.tgz",
+      "resolved": "https://registry.npmjs.org/graphql-codegen-core/-/graphql-codegen-core-0.8.21.tgz",
       "integrity": "sha1-Cknq4nTFXvP7iC2eGJz1oVLvLu0=",
       "requires": {
         "graphql-tag": "2.8.0",
@@ -3234,7 +3235,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
@@ -3299,7 +3300,7 @@
     },
     "moment": {
       "version": "2.21.0",
-      "resolved": "http://registry.npmjs.org/moment/-/moment-2.21.0.tgz",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.21.0.tgz",
       "integrity": "sha512-TCZ36BjURTeFTM/CwRcViQlfkMvL1/vFISuNLO5GkcVm1+QHfbSiNqZuWeMFjj1/3+uAjXswgRk30j1kkLYJBQ=="
     },
     "ms": {
@@ -4825,7 +4826,7 @@
         },
         "typescript": {
           "version": "2.7.2",
-          "resolved": "http://registry.npmjs.org/typescript/-/typescript-2.7.2.tgz",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.2.tgz",
           "integrity": "sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw==",
           "dev": true
         }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@atomist/microgrammar": "^0.8.1",
     "@atomist/slack-messages": "^0.12.1",
-    "@atomist/tree-path": "^0.1.9",
+    "@atomist/tree-path": "https://r.atomist.com/1089073149",
     "@octokit/rest": "^14.0.9",
     "@typed/curry": "^1.0.1",
     "@types/app-root-path": "^1.2.4",

--- a/src/tree/LocatedTreeNode.ts
+++ b/src/tree/LocatedTreeNode.ts
@@ -1,4 +1,4 @@
-import { TreeNode } from "@atomist/tree-path/TreeNode";
+import { TreeNode } from "@atomist/tree-path";
 import { SourceLocation } from "../operations/common/SourceLocation";
 
 /**

--- a/src/tree/ast/FileHits.ts
+++ b/src/tree/ast/FileHits.ts
@@ -1,9 +1,4 @@
-import { evaluateExpression } from "@atomist/tree-path/path/expressionEngine";
-import {
-    isSuccessResult,
-    PathExpression,
-} from "@atomist/tree-path/path/pathExpression";
-import { TreeNode } from "@atomist/tree-path/TreeNode";
+import { evaluateExpression, isSuccessResult, PathExpression, TreeNode } from "@atomist/tree-path";
 import { ScriptedFlushable } from "../../internal/common/Flushable";
 import { File } from "../../project/File";
 import {

--- a/src/tree/ast/FileParser.ts
+++ b/src/tree/ast/FileParser.ts
@@ -1,8 +1,8 @@
-import { PathExpression } from "@atomist/tree-path/path/pathExpression";
-import { TreeNode } from "@atomist/tree-path/TreeNode";
+import { PathExpression, TreeNode } from "@atomist/tree-path";
 import { File } from "../../project/File";
 
 /**
+ * Central interface for integration of trees and path expressions into the Atomist Project API.
  * Implemented by objects that can parse a file into an AST using a single grammar
  */
 export interface FileParser {

--- a/src/tree/ast/FileParserRegistry.ts
+++ b/src/tree/ast/FileParserRegistry.ts
@@ -1,10 +1,10 @@
-import { SelfAxisSpecifier } from "@atomist/tree-path/path/axisSpecifiers";
-import { isNamedNodeTest } from "@atomist/tree-path/path/nodeTests";
 import {
+    isNamedNodeTest,
     isUnionPathExpression,
     PathExpression,
-} from "@atomist/tree-path/path/pathExpression";
-import { toPathExpression } from "@atomist/tree-path/path/utils";
+    SelfAxisSpecifier,
+    toPathExpression,
+} from "@atomist/tree-path";
 import { Dictionary } from "lodash";
 import { FileParser } from "./FileParser";
 

--- a/src/tree/ast/astUtils.ts
+++ b/src/tree/ast/astUtils.ts
@@ -1,32 +1,22 @@
-import { defineDynamicProperties } from "@atomist/tree-path/manipulation/enrichment";
-import { evaluateExpression } from "@atomist/tree-path/path/expressionEngine";
 import {
+    defineDynamicProperties,
+    evaluateExpression,
     isSuccessResult,
     PathExpression,
     stringify,
-} from "@atomist/tree-path/path/pathExpression";
-import { toPathExpression } from "@atomist/tree-path/path/utils";
-import { TreeNode } from "@atomist/tree-path/TreeNode";
+    toPathExpression,
+    TreeNode,
+} from "@atomist/tree-path";
 import * as _ from "lodash";
 import { logger } from "../../util/logger";
 
 import { File } from "../../project/File";
 import { ProjectAsync } from "../../project/Project";
-import {
-    gatherFromFiles,
-    GlobOptions,
-} from "../../project/util/projectUtils";
+import { gatherFromFiles, GlobOptions } from "../../project/util/projectUtils";
 import { toSourceLocation } from "../../project/util/sourceLocationUtils";
 import { LocatedTreeNode } from "../LocatedTreeNode";
-import {
-    FileHit,
-    MatchResult,
-    NodeReplacementOptions,
-} from "./FileHits";
-import {
-    FileParser,
-    isFileParser,
-} from "./FileParser";
+import { FileHit, MatchResult, NodeReplacementOptions } from "./FileHits";
+import { FileParser, isFileParser } from "./FileParser";
 import { FileParserRegistry } from "./FileParserRegistry";
 
 /**

--- a/src/tree/ast/microgrammar/MicrogrammarBasedFileParser.ts
+++ b/src/tree/ast/microgrammar/MicrogrammarBasedFileParser.ts
@@ -6,9 +6,9 @@ import {
 import {
     defineDynamicProperties,
     fillInEmptyNonTerminalValues,
-} from "@atomist/tree-path/manipulation/enrichment";
+    TreeNode,
+} from "@atomist/tree-path";
 
-import { TreeNode } from "@atomist/tree-path/TreeNode";
 import { File } from "../../../project/File";
 import { FileParser } from "../FileParser";
 

--- a/src/tree/ast/typescript/TypeScriptFileParser.ts
+++ b/src/tree/ast/typescript/TypeScriptFileParser.ts
@@ -1,15 +1,13 @@
 import {
     AllNodeTest,
     isNamedNodeTest,
-} from "@atomist/tree-path/path/nodeTests";
-import {
     isUnionPathExpression,
     LocationStep,
     PathExpression,
     stringify,
-} from "@atomist/tree-path/path/pathExpression";
+    TreeNode,
+} from "@atomist/tree-path";
 
-import { TreeNode } from "@atomist/tree-path/TreeNode";
 import * as _ from "lodash";
 import * as ts from "typescript";
 import { File } from "../../../project/File";
@@ -81,7 +79,6 @@ function scriptKindFor(f: File): ts.ScriptKind {
     }
 }
 
-// TODO coming from newer path expression support
 function locationSteps(pex: PathExpression): LocationStep[] {
     return isUnionPathExpression(pex) ?
         _.flatten(pex.unions.map(p => locationSteps(p))) :

--- a/test/tree/ast/microgrammar/MicrogrammarBasedFileParserTest.ts
+++ b/test/tree/ast/microgrammar/MicrogrammarBasedFileParserTest.ts
@@ -1,10 +1,10 @@
 import { Microgrammar } from "@atomist/microgrammar/Microgrammar";
 import { Integer } from "@atomist/microgrammar/Primitives";
-import { TreeNode } from "@atomist/tree-path/TreeNode";
 import {
+    TreeNode,
     TreeVisitor,
     visit,
-} from "@atomist/tree-path/visitor";
+} from "@atomist/tree-path";
 import "mocha";
 import * as assert from "power-assert";
 import { InMemoryFile } from "../../../../src/project/mem/InMemoryFile";

--- a/test/tree/ast/typescript/TypeScriptFileParserTest.ts
+++ b/test/tree/ast/typescript/TypeScriptFileParserTest.ts
@@ -3,12 +3,10 @@ import {
     evaluateScalar,
     evaluateScalarValue,
     evaluateScalarValues,
-} from "@atomist/tree-path/path/expressionEngine";
-import { TreeNode } from "@atomist/tree-path/TreeNode";
-import {
+    TreeNode,
     TreeVisitor,
     visit,
-} from "@atomist/tree-path/visitor";
+} from "@atomist/tree-path";
 import "mocha";
 import * as assert from "power-assert";
 import { InMemoryFile } from "../../../../src/project/mem/InMemoryFile";

--- a/test/tree/ast/typescript/conversionTests.ts
+++ b/test/tree/ast/typescript/conversionTests.ts
@@ -1,7 +1,6 @@
 import { CFamilyLangHelper } from "@atomist/microgrammar/matchers/lang/cfamily/CFamilyLangHelper";
 
-import { UnionPathExpression } from "@atomist/tree-path/path/pathExpression";
-import { parsePathExpression } from "@atomist/tree-path/path/pathExpressionParser";
+import { parsePathExpression, UnionPathExpression } from "@atomist/tree-path";
 import "mocha";
 import * as assert from "power-assert";
 import { InMemoryFile } from "../../../../src/project/mem/InMemoryFile";


### PR DESCRIPTION
Upgraded `tree-path` library to benefit from a bug fix in handling tree node attribute tests. However, it turned out that the version of `tree-path` used was very old and upgrading necessitated extensive import changes (which are all improvements, being from the index).

No change to actual implementation of `automation-client`.