### PR TITLE
Export cross-spawn as spawn

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -353,6 +353,9 @@ export {
     QueryNoCacheOptions,
     QueryOptions,
 } from "./lib/spi/graph/GraphClient";
+export * from "./lib/spi/http/axiosHttpClient";
+export * from "./lib/spi/http/curlHttpClient";
+export * from "./lib/spi/http/httpClient";
 export * from "./lib/spi/message/MessageClient";
 export {
     DefaultSlackMessageClient,
@@ -397,10 +400,6 @@ export {
 export {
     doWithRetry,
 } from "./lib/util/retry";
-
-export * from "./lib/spi/http/axiosHttpClient";
-export * from "./lib/spi/http/curlHttpClient";
-export * from "./lib/spi/http/httpClient";
 export * from "./lib/util/spawn";
 import * as GraphQL from "./lib/graph/graphQL";
 export { GraphQL };

--- a/lib/util/spawn.ts
+++ b/lib/util/spawn.ts
@@ -25,6 +25,8 @@ import { sprintf } from "sprintf-js";
 import * as strip_ansi from "strip-ansi";
 import { logger } from "./logger";
 
+export { spawn };
+
 export interface WritableLog {
 
     /**


### PR DESCRIPTION
So we can have a common spawn and exec to run from SDMs/clients.